### PR TITLE
Fix tests and optional Message.user

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,4 +11,4 @@ dependencies:
 
 test:
   override:
-    - stack test --test-arguments "$BOT_TOKEN $CHAT_ID"
+    - stack test --test-arguments "$BOT_TOKEN $CHAT_ID $BOT_NAME"

--- a/src/Web/Telegram/API/Bot/Data.hs
+++ b/src/Web/Telegram/API/Bot/Data.hs
@@ -375,7 +375,7 @@ data UserProfilePhotos = UserProfilePhotos
 data Message = Message
   {
     message_id :: Int                     -- ^ Unique message identifier
-  , from :: User                          -- ^ Sender, can be empty for messages sent to channels
+  , from :: Maybe User                        -- ^ Sender, can be empty for messages sent to channels
   , date :: Int                           -- ^ Date the message was sent in Unix time
   , chat :: Chat                          -- ^ Conversation the message belongs to
   , forward_from :: Maybe User            -- ^ For forwarded messages, sender of the original message

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -28,15 +28,17 @@ main = do
 runSpec :: [String] -> SpecWith ()
 runSpec [] = do
   describe "NoTests" $ do
-    it "Does not run integration tests if no token and chat id provided" $ do
+    it "Does not run integration tests if no token, chat id and boot name provided" $ do
       pending
 
-runSpec [tkn,cId] = do
+runSpec [tkn,cId,bNm] = do
     let token = Token (T.pack tkn)
     let chatId = T.pack cId
-    runSpec' token chatId
+    let botName = T.pack bNm
+    runSpec' token chatId botName
 
-runSpec' :: Token -> Text -> SpecWith ()
-runSpec' token chatId = do
-    describe "Main" $ MainSpec.spec token chatId
-    --describe "Inline" $ InlineSpec.spec token chatId
+runSpec' :: Token -> Text -> Text -> SpecWith ()
+runSpec' token chatId botName = do
+    describe "Main" $ MainSpec.spec token chatId botName
+    --describe "Inline" $ InlineSpec.spec token chatId botName
+


### PR DESCRIPTION
Changes:
* Add testing `botName` argument (my own is not TelegramAPIBot).
* Check response fail/success on tests to print out remote response.
* Optional Message.user
