### PR TITLE
Fix missing disable_notification in all request data types 

### DIFF
--- a/src/Web/Telegram/API/Bot/Requests.hs
+++ b/src/Web/Telegram/API/Bot/Requests.hs
@@ -64,8 +64,8 @@ data ForwardMessageRequest = ForwardMessageRequest
   {
     forward_chat_id :: Text -- ^ Unique identifier for the target chat or username of the target channel (in the format @@channelusername@)
   , forward_from_chat_id :: Text -- ^ Unique identifier for the chat where the original message was sent (or channel username in the format @@channelusername@)
-  , forward_mesage_id :: Int -- ^ Unique message identifier
   , forward_disable_notification     :: Maybe Bool -- ^ Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+  , forward_message_id :: Int -- ^ Unique message identifier
   } deriving (Show, Generic)
 
 instance ToJSON ForwardMessageRequest where
@@ -77,12 +77,12 @@ instance FromJSON ForwardMessageRequest where
 -- | This object represents request for 'sendPhoto'
 data SendPhotoRequest = SendPhotoRequest
   {
-    photo_chat_id             :: Text -- ^ Unique identifier for the target chat or username of the target channel (in the format @@channelusername@)
-  , photo_photo               :: Text -- ^ Photo to send. Pass a file_id as String to resend a photo that is already on the Telegram servers
-  , photo_caption             :: Maybe Text -- ^ Photo caption (may also be used when resending photos by file_id), 0-200 characters.
+    photo_chat_id              :: Text -- ^ Unique identifier for the target chat or username of the target channel (in the format @@channelusername@)
+  , photo_photo                :: Text -- ^ Photo to send. Pass a file_id as String to resend a photo that is already on the Telegram servers
+  , photo_caption              :: Maybe Text -- ^ Photo caption (may also be used when resending photos by file_id), 0-200 characters.
   , photo_disable_notification :: Maybe Bool -- ^ Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-  , photo_reply_to_message_id :: Maybe Int -- ^ If the message is a reply, ID of the original message
-  , photo_reply_markup        :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+  , photo_reply_to_message_id  :: Maybe Int -- ^ If the message is a reply, ID of the original message
+  , photo_reply_markup         :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
   } deriving (Show, Generic)
 
 instance ToJSON SendPhotoRequest where
@@ -94,14 +94,14 @@ instance FromJSON SendPhotoRequest where
 -- | This object represents request for 'sendAudio'
 data SendAudioRequest = SendAudioRequest
   {
-    _audio_chat_id             :: Text -- ^ Unique identifier for the target chat or username of the target channel (in the format @@channelusername@)
-  , _audio_audio               :: Text -- ^ Audio file to send. Pass a file_id as String to resend an audio that is already on the Telegram servers.
-  , _audio_duration            :: Maybe Int -- ^ Duration of the audio in seconds
-  , _audio_performer           :: Maybe Text -- ^ Performer
-  , _audio_title               :: Maybe Text -- ^ Track name
-  , _audio_reply_to_message_id :: Maybe Int -- ^ If the message is a reply, ID of the original message
-  , _audio_reply_markup        :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+    _audio_chat_id              :: Text -- ^ Unique identifier for the target chat or username of the target channel (in the format @@channelusername@)
+  , _audio_audio                :: Text -- ^ Audio file to send. Pass a file_id as String to resend an audio that is already on the Telegram servers.
+  , _audio_duration             :: Maybe Int -- ^ Duration of the audio in seconds
+  , _audio_performer            :: Maybe Text -- ^ Performer
+  , _audio_title                :: Maybe Text -- ^ Track name
   , _audio_disable_notification :: Maybe Bool -- ^ Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+  , _audio_reply_to_message_id  :: Maybe Int -- ^ If the message is a reply, ID of the original message
+  , _audio_reply_markup         :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
   } deriving (Show, Generic)
 
 instance ToJSON SendAudioRequest where
@@ -198,15 +198,15 @@ instance FromJSON SendLocationRequest where
 -- | This object represents request for 'sendVenue'
 data SendVenueRequest = SendVenueRequest
   {
-    _venue_chat_id             :: Text -- ^ Unique identifier for the target chat or username of the target channel (in the format @@channelusername@)
-  , _venue_latitude            :: Float -- ^ Latitude of the venue
-  , _venue_longitude           :: Float -- ^ Longitude of the venue
-  , _venue_title               :: Text -- ^ Name of the venue
-  , _venue_address             :: Text -- ^ Address of the venue
-  , _venue_foursquare_id       :: Maybe Text -- ^ Foursquare identifier of the venue
-  , _venue_reply_to_message_id :: Maybe Int -- ^ If the message is a reply, ID of the original message
-  , _venue_reply_markup        :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+    _venue_chat_id               :: Text -- ^ Unique identifier for the target chat or username of the target channel (in the format @@channelusername@)
+  , _venue_latitude              :: Float -- ^ Latitude of the venue
+  , _venue_longitude             :: Float -- ^ Longitude of the venue
+  , _venue_title                 :: Text -- ^ Name of the venue
+  , _venue_address               :: Text -- ^ Address of the venue
+  , _venue_foursquare_id         :: Maybe Text -- ^ Foursquare identifier of the venue
   , _venue_disable_notification  :: Maybe Bool -- ^ Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+  , _venue_reply_to_message_id   :: Maybe Int -- ^ If the message is a reply, ID of the original message
+  , _venue_reply_markup          :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
   } deriving (Show, Generic)
 
 instance ToJSON SendVenueRequest where
@@ -218,13 +218,13 @@ instance FromJSON SendVenueRequest where
 -- | This object represents request for 'sendContact'
 data SendContactRequest = SendContactRequest
   {
-    _contact_chat_id             :: Text -- ^ Unique identifier for the target chat or username of the target channel (in the format @@channelusername@)
-  , _contact_phone_number        :: Text       -- ^ Contact's phone number
-  , _contact_first_name          :: Text       -- ^ Contact's first name
-  , _contact_last_name           :: Maybe Text -- ^ Contact's last name
-  , _contact_reply_to_message_id :: Maybe Int -- ^ If the message is a reply, ID of the original message
-  , _contact_reply_markup        :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+    _contact_chat_id              :: Text -- ^ Unique identifier for the target chat or username of the target channel (in the format @@channelusername@)
+  , _contact_phone_number         :: Text       -- ^ Contact's phone number
+  , _contact_first_name           :: Text       -- ^ Contact's first name
+  , _contact_last_name            :: Maybe Text -- ^ Contact's last name
   , _contact_disable_notification :: Maybe Bool -- ^ Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+  , _contact_reply_to_message_id  :: Maybe Int -- ^ If the message is a reply, ID of the original message
+  , _contact_reply_markup         :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
   } deriving (Show, Generic)
 
 instance ToJSON SendContactRequest where

--- a/src/Web/Telegram/API/Bot/Requests.hs
+++ b/src/Web/Telegram/API/Bot/Requests.hs
@@ -48,6 +48,7 @@ data SendMessageRequest = SendMessageRequest
   , message_text                     :: Text -- ^ Text of the message to be sent
   , message_parse_mode               :: Maybe ParseMode -- ^ Send 'Markdown', if you want Telegram apps to show bold, italic and inline URLs in your bot's message
   , message_disable_web_page_preview :: Maybe Bool -- ^ Disables link previews for links in this message
+  , message_disable_notification     :: Maybe Bool -- ^ Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
   , message_reply_to_message_id      :: Maybe Int -- ^ If the message is a reply, ID of the original message
   , message_reply_markup             :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
   } deriving (Show, Generic)
@@ -64,6 +65,7 @@ data ForwardMessageRequest = ForwardMessageRequest
     forward_chat_id :: Text -- ^ Unique identifier for the target chat or username of the target channel (in the format @@channelusername@)
   , forward_from_chat_id :: Text -- ^ Unique identifier for the chat where the original message was sent (or channel username in the format @@channelusername@)
   , forward_mesage_id :: Int -- ^ Unique message identifier
+  , forward_disable_notification     :: Maybe Bool -- ^ Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
   } deriving (Show, Generic)
 
 instance ToJSON ForwardMessageRequest where
@@ -78,6 +80,7 @@ data SendPhotoRequest = SendPhotoRequest
     photo_chat_id             :: Text -- ^ Unique identifier for the target chat or username of the target channel (in the format @@channelusername@)
   , photo_photo               :: Text -- ^ Photo to send. Pass a file_id as String to resend a photo that is already on the Telegram servers
   , photo_caption             :: Maybe Text -- ^ Photo caption (may also be used when resending photos by file_id), 0-200 characters.
+  , photo_disable_notification :: Maybe Bool -- ^ Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
   , photo_reply_to_message_id :: Maybe Int -- ^ If the message is a reply, ID of the original message
   , photo_reply_markup        :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
   } deriving (Show, Generic)
@@ -98,6 +101,7 @@ data SendAudioRequest = SendAudioRequest
   , _audio_title               :: Maybe Text -- ^ Track name
   , _audio_reply_to_message_id :: Maybe Int -- ^ If the message is a reply, ID of the original message
   , _audio_reply_markup        :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+  , _audio_disable_notification :: Maybe Bool -- ^ Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
   } deriving (Show, Generic)
 
 instance ToJSON SendAudioRequest where
@@ -111,6 +115,7 @@ data SendStickerRequest = SendStickerRequest
   {
     sticker_chat_id                  :: Text -- ^ Unique identifier for the target chat or username of the target channel (in the format @@channelusername@)
   , sticker_sticker                  :: Text -- ^ Sticker to send. A file_id as String to resend a sticker that is already on the Telegram servers
+  , sticker_disable_notification     :: Maybe Bool -- ^ Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
   , sticker_reply_to_message_id      :: Maybe Int -- ^ If the message is a reply, ID of the original message
   , sticker_reply_markup             :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
   } deriving (Show, Generic)
@@ -126,6 +131,8 @@ data SendDocumentRequest = SendDocumentRequest
   {
     document_chat_id                  :: Text -- ^ Unique identifier for the target chat or username of the target channel (in the format @@channelusername@)
   , document_document                 :: Text -- ^ File to send. A file_id as String to resend a file that is already on the Telegram servers
+  , document_caption                  :: Maybe Text -- ^ Document caption (may also be used when resending documents by file_id), 0-200 characters
+  , document_disable_notification     :: Maybe Bool -- ^ Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
   , document_reply_to_message_id      :: Maybe Int -- ^ If the message is a reply, ID of the original message
   , document_reply_markup             :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
   } deriving (Show, Generic)
@@ -143,6 +150,7 @@ data SendVideoRequest = SendVideoRequest
   , _video_video                    :: Text -- ^ Video to send. A file_id as String to resend a video that is already on the Telegram servers
   , _video_duration                 :: Maybe Int -- ^ Duration of sent video in seconds
   , _video_caption                  :: Maybe Text -- ^ Video caption, 0-200 characters.
+  , _video_disable_notification     :: Maybe Bool -- ^ Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
   , _video_reply_to_message_id      :: Maybe Int -- ^ If the message is a reply, ID of the original message
   , _video_reply_markup             :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
   } deriving (Show, Generic)
@@ -159,6 +167,7 @@ data SendVoiceRequest = SendVoiceRequest
     _voice_chat_id                  :: Text -- ^ Unique identifier for the target chat or username of the target channel (in the format @@channelusername@)
   , _voice_voice                    :: Text -- ^ Audio file to send. A file_id as String to resend an audio that is already on the Telegram servers
   , _voice_duration                 :: Maybe Int -- ^ Duration of sent audio in seconds
+  , _voice_disable_notification     :: Maybe Bool -- ^ Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
   , _voice_reply_to_message_id      :: Maybe Int -- ^ If the message is a reply, ID of the original message
   , _voice_reply_markup             :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
   } deriving (Show, Generic)
@@ -175,6 +184,7 @@ data SendLocationRequest = SendLocationRequest
     location_chat_id                :: Text -- ^ Unique identifier for the target chat or username of the target channel (in the format @@channelusername@)
   , location_latitude               :: Float -- ^ Latitude of location
   , location_longitude              :: Float -- ^ Longitude of location
+  , location_disable_notification   :: Maybe Bool -- ^ Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
   , location_reply_to_message_id    :: Maybe Int -- ^ If the message is a reply, ID of the original message
   , location_reply_markup           :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
   } deriving (Show, Generic)
@@ -196,6 +206,7 @@ data SendVenueRequest = SendVenueRequest
   , _venue_foursquare_id       :: Maybe Text -- ^ Foursquare identifier of the venue
   , _venue_reply_to_message_id :: Maybe Int -- ^ If the message is a reply, ID of the original message
   , _venue_reply_markup        :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+  , _venue_disable_notification  :: Maybe Bool -- ^ Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
   } deriving (Show, Generic)
 
 instance ToJSON SendVenueRequest where
@@ -213,6 +224,7 @@ data SendContactRequest = SendContactRequest
   , _contact_last_name           :: Maybe Text -- ^ Contact's last name
   , _contact_reply_to_message_id :: Maybe Int -- ^ If the message is a reply, ID of the original message
   , _contact_reply_markup        :: Maybe ReplyKeyboard -- ^ Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+  , _contact_disable_notification :: Maybe Bool -- ^ Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
   } deriving (Show, Generic)
 
 instance ToJSON SendContactRequest where

--- a/test/MainSpec.hs
+++ b/test/MainSpec.hs
@@ -33,44 +33,44 @@ spec token chatId botName = do
 
   describe "/sendMessage" $ do
     it "should send message" $ do
-      res <- sendMessage token (SendMessageRequest chatId "test message" Nothing Nothing Nothing Nothing) manager
+      res <- sendMessage token (SendMessageRequest chatId "test message" Nothing Nothing Nothing Nothing Nothing) manager
       success res 
       let Right MessageResponse { message_result = m } = res
       (text m) `shouldBe` (Just "test message")
 
     it "should return error message" $ do
-      res <- sendMessage token (SendMessageRequest "" "test message" Nothing Nothing Nothing Nothing) manager
+      res <- sendMessage token (SendMessageRequest "" "test message" Nothing Nothing Nothing Nothing Nothing) manager
       nosuccess res
       let Left FailureResponse { responseStatus = Status { statusMessage = msg } } = res
       msg `shouldBe` "Bad Request"
 
     it "should send message markdown" $ do
-      res <- sendMessage token (SendMessageRequest chatId "text *bold* _italic_ [github](github.com/klappvisor/telegram-api)" (Just Markdown) Nothing Nothing Nothing) manager
+      res <- sendMessage token (SendMessageRequest chatId "text *bold* _italic_ [github](github.com/klappvisor/telegram-api)" (Just Markdown) Nothing Nothing Nothing Nothing) manager
       success res
       let Right MessageResponse { message_result = m } = res
       (text m) `shouldBe` (Just "text bold italic github")
 
     it "should set keyboard" $ do
-      res <- sendMessage token (SendMessageRequest chatId "set keyboard" Nothing Nothing Nothing (Just (ReplyKeyboardMarkup [["A", "B"], ["C"]] Nothing Nothing Nothing))) manager
+      res <- sendMessage token (SendMessageRequest chatId "set keyboard" Nothing Nothing Nothing Nothing (Just (ReplyKeyboardMarkup [["A", "B"], ["C"]] Nothing Nothing Nothing))) manager
       success res
       let Right MessageResponse { message_result = m } = res
       (text m) `shouldBe` (Just "set keyboard")
 
     it "should remove keyboard" $ do
-      res <- sendMessage token (SendMessageRequest chatId "remove keyboard" Nothing Nothing Nothing (Just (ReplyKeyboardHide True Nothing))) manager
+      res <- sendMessage token (SendMessageRequest chatId "remove keyboard" Nothing Nothing Nothing Nothing (Just (ReplyKeyboardHide True Nothing))) manager
       success res
       let Right MessageResponse { message_result = m } = res
       (text m) `shouldBe` (Just "remove keyboard")
 
     it "should force reply" $ do
-      res <- sendMessage token (SendMessageRequest chatId "force reply" Nothing Nothing Nothing (Just (ForceReply True Nothing))) manager
+      res <- sendMessage token (SendMessageRequest chatId "force reply" Nothing Nothing Nothing Nothing (Just (ForceReply True Nothing))) manager
       success res
       let Right MessageResponse { message_result = m } = res
       (text m) `shouldBe` (Just "force reply")
 
   describe "/forwardMessage" $ do
     it "should forward message" $ do
-      res <- forwardMessage token (ForwardMessageRequest chatId chatId 123) manager
+      res <- forwardMessage token (ForwardMessageRequest chatId chatId Nothing 123) manager
       nosuccess res
       let Left FailureResponse { responseStatus = Status { statusMessage = msg } } = res
       msg `shouldBe` "Bad Request"
@@ -78,47 +78,47 @@ spec token chatId botName = do
   describe "/sendPhoto" $ do
     it "should return error message" $ do
       Left FailureResponse { responseStatus = Status { statusMessage = msg } } <-
-        sendPhoto token (SendPhotoRequest "" "photo_id" (Just "photo caption") Nothing Nothing) manager
+        sendPhoto token (SendPhotoRequest "" "photo_id" (Just "photo caption") Nothing Nothing Nothing) manager
       msg `shouldBe` "Bad Request"
     it "should send photo" $ do
      Right MessageResponse { message_result = Message { caption = Just cpt } } <-
-       sendPhoto token (SendPhotoRequest chatId catPic (Just "photo caption") Nothing Nothing) manager
+       sendPhoto token (SendPhotoRequest chatId catPic (Just "photo caption") Nothing Nothing Nothing) manager
      cpt `shouldBe` "photo caption"
 
   describe "/sendAudio" $ do
     it "should return error message" $ do
       Left FailureResponse { responseStatus = Status { statusMessage = msg } } <-
-        sendAudio token (SendAudioRequest "" "audio_id" Nothing (Just "performer") (Just "title") Nothing Nothing) manager
+        sendAudio token (SendAudioRequest "" "audio_id" Nothing (Just "performer") (Just "title") Nothing Nothing Nothing) manager
       msg `shouldBe` "Bad Request"
     it "should send audio" $ do
       Right MessageResponse { message_result = Message { audio = Just Audio { audio_title = Just title } } } <-
-        sendAudio token (SendAudioRequest chatId "BQADBAADAQQAAiBOnQHThzc4cz1-IwI" Nothing Nothing Nothing Nothing Nothing) manager
+        sendAudio token (SendAudioRequest chatId "BQADBAADAQQAAiBOnQHThzc4cz1-IwI" Nothing Nothing Nothing Nothing Nothing Nothing) manager
       title `shouldBe` "The Nutcracker Suite - Act II, No.12. Pas de Deux variations"
 
   describe "/sendSticker" $ do
     it "should send sticker" $ do
       Right MessageResponse { message_result = Message { sticker = Just sticker } } <-
-        sendSticker token (SendStickerRequest chatId "BQADAgADGgADkWgMAAGXlYGBiM_d2wI" Nothing Nothing) manager
+        sendSticker token (SendStickerRequest chatId "BQADAgADGgADkWgMAAGXlYGBiM_d2wI" Nothing Nothing Nothing) manager
       (sticker_file_id sticker) `shouldBe` "BQADAgADGgADkWgMAAGXlYGBiM_d2wI"
 
   describe "/sendLocation" $ do
     it "should send location" $ do
       Right MessageResponse { message_result = Message { location = Just loc } } <-
-        sendLocation token (SendLocationRequest chatId 52.38 4.9 Nothing Nothing) manager
+        sendLocation token (SendLocationRequest chatId 52.38 4.9 Nothing Nothing Nothing) manager
       (latitude loc) `shouldSatisfy` (liftM2 (&&) (> 52) (< 52.4))
       (longitude loc) `shouldSatisfy` (liftM2 (&&) (> 4.89) (< 5))
 
   describe "/sendVenue" $ do
     it "should send a venue" $ do
       Right MessageResponse { message_result = Message { location = Just loc } } <-
-        sendVenue token (SendVenueRequest chatId 52.38 4.9 "Amsterdam Centraal" "Amsterdam" Nothing Nothing Nothing) manager
+        sendVenue token (SendVenueRequest chatId 52.38 4.9 "Amsterdam Centraal" "Amsterdam" Nothing Nothing Nothing Nothing) manager
       (latitude loc) `shouldSatisfy` (liftM2 (&&) (> 52) (< 52.4))
       (longitude loc) `shouldSatisfy` (liftM2 (&&) (> 4.89) (< 5))
 
   describe "/sendContact" $ do
     it "should send a contact" $ do
       Right MessageResponse { message_result = Message { contact = Just con } } <-
-        sendContact token (SendContactRequest chatId "06-18035176" "Hilbert" Nothing Nothing Nothing) manager
+        sendContact token (SendContactRequest chatId "06-18035176" "Hilbert" Nothing Nothing Nothing Nothing) manager
       -- Telegram seems to remove any non numeric characters from the sent phone number (at least it removed my '-')
       (contact_phone_number con) `shouldBe` "0618035176"
       (contact_first_name con) `shouldBe` "Hilbert"
@@ -173,7 +173,7 @@ spec token chatId botName = do
 
   describe "/editTextMessage" $ do
     it "should edit message" $ do
-      let originalMessage = SendMessageRequest chatId "veritas" Nothing Nothing Nothing Nothing
+      let originalMessage = SendMessageRequest chatId "veritas" Nothing Nothing Nothing Nothing Nothing
       Right MessageResponse { message_result = Message { message_id = msg_id, text = Just txt } } <-
         sendMessage token originalMessage manager
       Right MessageResponse { message_result = Message { text = txt' } } <-
@@ -181,7 +181,7 @@ spec token chatId botName = do
       txt' `shouldBe` Just "edited veritas"
 
     it "should edit caption" $ do
-      let originalMessage = SendPhotoRequest chatId catPic (Just "cat picture") Nothing Nothing
+      let originalMessage = SendPhotoRequest chatId catPic (Just "cat picture") Nothing Nothing Nothing
       Right MessageResponse { message_result = Message { message_id = msg_id, caption = Just cpt } } <-
         sendPhoto token originalMessage manager
       Right MessageResponse { message_result = Message { caption = Just cpt' } } <-


### PR DESCRIPTION
Should fix issue [34](https://github.com/klappvisor/haskell-telegram-api/issues/34).

I also added a `caption` field in `SendDocumentRequest` and renamed `forward_mesage_id` to `forward_message_id` in `ForwardMessageRequest`.