### PR TITLE
Add KeyboardButton

### DIFF
--- a/src/Web/Telegram/API/Bot/Data.hs
+++ b/src/Web/Telegram/API/Bot/Data.hs
@@ -31,6 +31,7 @@ module Web.Telegram.API.Bot.Data
     , ChatType                      (..)
     , ParseMode                     (..)
     , InputMessageContent           (..)
+    , KeyboardButton                (..)
     ) where
 
 import           Data.Aeson
@@ -511,3 +512,16 @@ instance ToJSON Venue where
 
 instance FromJSON Venue where
   parseJSON = parseJsonDrop 6
+
+data KeyboardButton = KeyboardButton
+  {
+    kb_text             :: Text -- ^ Text of the button. If none of the optional fields are used, it will be sent to the bot as a message when the button is pressed
+  , kb_request_contact  :: Maybe Bool -- ^ If True, the user's phone number will be sent as a contact when the button is pressed. Available in private chats only
+  , kb_request_location :: Maybe Bool -- ^ If True, the user's current location will be sent when the button is pressed. Available in private chats only
+  } deriving (Show, Generic)
+
+instance ToJSON KeyboardButton where
+  toJSON = toJsonDrop 3
+
+instance FromJSON KeyboardButton where
+  parseJSON = parseJsonDrop 3

--- a/src/Web/Telegram/API/Bot/Requests.hs
+++ b/src/Web/Telegram/API/Bot/Requests.hs
@@ -310,7 +310,7 @@ data ReplyKeyboard =
   -- | This object represents a custom keyboard with reply options
   ReplyKeyboardMarkup
   {
-    reply_keyboard             :: [[Text]] -- ^ Array of button rows, each represented by an Array of Strings
+    reply_keyboard             :: [[KeyboardButton]] -- ^ Array of button rows, each represented by an Array of 'KeyboardButton' objects
   , reply_resize_keyboard      :: Maybe Bool -- ^ Requests clients to resize the keyboard vertically for optimal fit (e.g., make the keyboard smaller if there are just two rows of buttons). Defaults to false, in which case the custom keyboard is always of the same height as the app's standard keyboard.
   , reply_one_time_keyboard    :: Maybe Bool -- ^ Requests clients to hide the keyboard as soon as it's been used. Defaults to false.
   , reply_selective            :: Maybe Bool -- ^ Use this parameter if you want to show the keyboard to specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), sender of the original message.    Example: A user requests to change the bot‘s language, bot replies to the request with a keyboard to select the new language. Other users in the group don’t see the keyboard.

--- a/test/MainSpec.hs
+++ b/test/MainSpec.hs
@@ -51,7 +51,10 @@ spec token chatId botName = do
       (text m) `shouldBe` (Just "text bold italic github")
 
     it "should set keyboard" $ do
-      res <- sendMessage token (SendMessageRequest chatId "set keyboard" Nothing Nothing Nothing Nothing (Just (ReplyKeyboardMarkup [["A", "B"], ["C"]] Nothing Nothing Nothing))) manager
+      let kbA = KeyboardButton "A" Nothing Nothing
+          kbB = KeyboardButton "B" Nothing Nothing
+          kbC = KeyboardButton "C" Nothing Nothing
+      res <- sendMessage token (SendMessageRequest chatId "set keyboard" Nothing Nothing Nothing Nothing (Just (ReplyKeyboardMarkup [[kbA, kbB], [kbC]] Nothing Nothing Nothing))) manager
       success res
       let Right MessageResponse { message_result = m } = res
       (text m) `shouldBe` (Just "set keyboard")


### PR DESCRIPTION
Should fix issue [15](https://github.com/klappvisor/haskell-telegram-api/issues/15).

The type of `ReplyKeyboardMarkup.keyboard` now is `[[KeyboardButton]]` instead of `[[Text]]`.

