### PR TITLE
Add support to switch between inline mode and a private chat

### DIFF
--- a/src/Web/Telegram/API/Bot/Requests.hs
+++ b/src/Web/Telegram/API/Bot/Requests.hs
@@ -285,6 +285,15 @@ data AnswerInlineQueryRequest = AnswerInlineQueryRequest
   , query_cache_time      :: Maybe Int -- ^ The maximum amount of time in seconds that the result of the inline query may be cached on the server. Defaults to 300.
   , query_is_personal     :: Maybe Bool -- ^ Pass True, if results may be cached on the server side only for the user that sent the query. By default, results may be returned to any user who sends the same query
   , query_next_offset     :: Maybe Text -- ^ Pass the offset that a client should send in the next query with the same text to receive more results. Pass an empty string if there are no more results or if you don‘t support pagination. Offset length can’t exceed 64 bytes.
+  , query_switch_pm_text  :: Maybe Text -- ^ If passed, clients will display a button with specified text that switches the user to a private chat with the bot and sends the bot a start message with the parameter switch_pm_parameter
+  , query_switch_pm_parameter :: Maybe Text -- ^ Parameter for the start message sent to the bot when user presses the switch button
+                                            --
+                                            -- Example: An inline bot that sends YouTube videos can ask the user to connect the bot to 
+                                            -- their YouTube account to adapt search results accordingly. To do this, it displays a 
+                                            -- ‘Connect your YouTube account’ button above the results, or even before showing any. 
+                                            -- The user presses the button, switches to a private chat with the bot and, in doing so, 
+                                            -- passes a start parameter that instructs the bot to return an oauth link. Once done, 
+                                            -- the bot can offer a switch_inline button so that the user can easily return to the chat where they wanted to use the bot's inline capabilities.
   } deriving (Show, Generic)
 
 instance ToJSON AnswerInlineQueryRequest where

--- a/src/Web/Telegram/API/Bot/Requests.hs
+++ b/src/Web/Telegram/API/Bot/Requests.hs
@@ -280,12 +280,12 @@ instance FromJSON SendChatActionRequest where
 
 data AnswerInlineQueryRequest = AnswerInlineQueryRequest
   {
-    query_inline_query_id :: Text -- ^ Unique identifier for the answered query
-  , query_results         :: [InlineQueryResult] -- ^ A JSON-serialized array of results for the inline query
-  , query_cache_time      :: Maybe Int -- ^ The maximum amount of time in seconds that the result of the inline query may be cached on the server. Defaults to 300.
-  , query_is_personal     :: Maybe Bool -- ^ Pass True, if results may be cached on the server side only for the user that sent the query. By default, results may be returned to any user who sends the same query
-  , query_next_offset     :: Maybe Text -- ^ Pass the offset that a client should send in the next query with the same text to receive more results. Pass an empty string if there are no more results or if you don‘t support pagination. Offset length can’t exceed 64 bytes.
-  , query_switch_pm_text  :: Maybe Text -- ^ If passed, clients will display a button with specified text that switches the user to a private chat with the bot and sends the bot a start message with the parameter switch_pm_parameter
+    query_inline_query_id     :: Text -- ^ Unique identifier for the answered query
+  , query_results             :: [InlineQueryResult] -- ^ A JSON-serialized array of results for the inline query
+  , query_cache_time          :: Maybe Int -- ^ The maximum amount of time in seconds that the result of the inline query may be cached on the server. Defaults to 300.
+  , query_is_personal         :: Maybe Bool -- ^ Pass True, if results may be cached on the server side only for the user that sent the query. By default, results may be returned to any user who sends the same query
+  , query_next_offset         :: Maybe Text -- ^ Pass the offset that a client should send in the next query with the same text to receive more results. Pass an empty string if there are no more results or if you don‘t support pagination. Offset length can’t exceed 64 bytes.
+  , query_switch_pm_text      :: Maybe Text -- ^ If passed, clients will display a button with specified text that switches the user to a private chat with the bot and sends the bot a start message with the parameter switch_pm_parameter
   , query_switch_pm_parameter :: Maybe Text -- ^ Parameter for the start message sent to the bot when user presses the switch button
                                             --
                                             -- Example: An inline bot that sends YouTube videos can ask the user to connect the bot to 

--- a/test/InlineSpec.hs
+++ b/test/InlineSpec.hs
@@ -27,23 +27,23 @@ spec token chatId = do
   describe "/answerInlineQuery" $ do
     it "should answer with article" $ do
       Right InlineQueryResponse { query_result = res } <-
-        answerInlineQuery token (AnswerInlineQueryRequest inline_query_id [inline_article] Nothing Nothing Nothing) manager
+        answerInlineQuery token (AnswerInlineQueryRequest inline_query_id [inline_article] Nothing Nothing Nothing Nothing Nothing) manager
       res `shouldBe` True
     it "should answer with photo" $ do
       Right InlineQueryResponse { query_result = res } <-
-        answerInlineQuery token (AnswerInlineQueryRequest inline_query_id [inline_photo] Nothing Nothing Nothing) manager
+        answerInlineQuery token (AnswerInlineQueryRequest inline_query_id [inline_photo] Nothing Nothing Nothing Nothing Nothing) manager
       res `shouldBe` True
     it "should answer with gif" $ do
       Right InlineQueryResponse { query_result = res } <-
-        answerInlineQuery token (AnswerInlineQueryRequest inline_query_id [inline_gif] Nothing Nothing Nothing) manager
+        answerInlineQuery token (AnswerInlineQueryRequest inline_query_id [inline_gif] Nothing Nothing Nothing Nothing Nothing) manager
       res `shouldBe` True
     it "should answer with mpeg gif" $ do
       Right InlineQueryResponse { query_result = res } <-
-        answerInlineQuery token (AnswerInlineQueryRequest inline_query_id [inline_mpeg] Nothing Nothing Nothing) manager
+        answerInlineQuery token (AnswerInlineQueryRequest inline_query_id [inline_mpeg] Nothing Nothing Nothing Nothing Nothing) manager
       res `shouldBe` True
     it "should answer with video" $ do
       Right InlineQueryResponse { query_result = res } <-
-        answerInlineQuery token (AnswerInlineQueryRequest inline_query_id [inline_video] Nothing Nothing Nothing) manager
+        answerInlineQuery token (AnswerInlineQueryRequest inline_query_id [inline_video] Nothing Nothing Nothing Nothing Nothing) manager
       res `shouldBe` True
 
   describe "/answerInlineQuery" $ do
@@ -52,7 +52,7 @@ spec token chatId = do
         getUpdates token Nothing Nothing Nothing manager
       Update { inline_query = Just (InlineQuery { query_id = id } ) } <- pure (last updates)
       e <-
-        answerInlineQuery token (AnswerInlineQueryRequest id [inline_video] Nothing Nothing Nothing) manager
+        answerInlineQuery token (AnswerInlineQueryRequest id [inline_video] Nothing Nothing Nothing Nothing Nothing) manager
       putStrLn (show e)
 
 message_content = InputTextMessageContent "test message content" Nothing Nothing


### PR DESCRIPTION
Should fix issue [17](https://github.com/klappvisor/haskell-telegram-api/issues/17).

Ooops I just noticed that you assigned the issue to yourself, hopefully you hadn't already started.