### PR TITLE
Feature/default requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ import Web.Telegram.API.Bot
 
 main :: IO ()
 main = do
+  manager <- runIO $ newManager tlsManagerSettings
   Right GetMeResponse { user_result = u } <-
-    getMe token
+    getMe token manager
   T.putStrLn (user_first_name u)
   where token = Token "bot<token>" -- entire Token should be bot123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
 ```
@@ -43,8 +44,12 @@ import Web.Telegram.API.Bot
 
 main :: IO ()
 main = do
+  manager <- runIO $ newManager tlsManagerSettings
+  let request = sendMessageRequest chatId message {
+    message_parse_mode = Just Markdown
+  }
   Right MessageResponse { message_result = m } <-
-    sendMessage token (SendMessageRequest chatId message (Just Markdown) Nothing Nothing Nothing)
+    sendMessage token request manager
   T.putStrLn (message_id m)
   T.putStrLn (text m)
   where token = Token "bot<token>" -- entire Token should be bot123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11

--- a/README.md
+++ b/README.md
@@ -57,6 +57,27 @@ main = do
         message = "text *bold* _italic_ [github](github.com/klappvisor/haskell-telegram-api)"
 ```
 
+#### Note on requests:
+
+Many request data records have a lot of optional parameters which are usually redundant.
+There is two way of creating requests:In order to solve this issue new way of creating request is introduced:
+
+With data type constructor:
+```haskell
+let request = SendMessageRequest "chatId" "text" Nothing (Just True) Nothing Nothing Nothing
+```
+Using default instance:
+
+```haskell
+let request = sendMessageRequest "chatId" "text" -- only with required fields
+```
+
+```haskell
+let request = (sendMessageRequest "chatId" "text") {
+  message_disable_notification = Just True -- with optional fields
+}
+```
+
 ## Contribution
 
 Contributions are welcome!

--- a/src/Web/Telegram/API/Bot/Data.hs
+++ b/src/Web/Telegram/API/Bot/Data.hs
@@ -32,6 +32,9 @@ module Web.Telegram.API.Bot.Data
     , ParseMode                     (..)
     , InputMessageContent           (..)
     , KeyboardButton                (..)
+      -- * Functions
+    , inlineKeyboardButton
+    , keyboardButton
     ) where
 
 import           Data.Aeson
@@ -396,6 +399,9 @@ instance ToJSON InlineKeyboardButton where
 instance FromJSON InlineKeyboardButton where
   parseJSON = parseJsonDrop 4
 
+inlineKeyboardButton :: Text -> InlineKeyboardButton
+inlineKeyboardButton text = InlineKeyboardButton text Nothing Nothing Nothing
+
 data CallbackQuery = CallbackQuery
   {
     cq_id :: Text
@@ -525,3 +531,6 @@ instance ToJSON KeyboardButton where
 
 instance FromJSON KeyboardButton where
   parseJSON = parseJsonDrop 3
+
+keyboardButton :: Text -> KeyboardButton
+keyboardButton text = KeyboardButton text Nothing Nothing

--- a/src/Web/Telegram/API/Bot/Requests.hs
+++ b/src/Web/Telegram/API/Bot/Requests.hs
@@ -30,6 +30,25 @@ module Web.Telegram.API.Bot.Requests
     , EditMessageReplyMarkupRequest  (..)
      -- * Functions
     , sendMessageRequest
+    , forwardMessageRequest
+    , sendPhotoRequest
+    , sendAudioRequest
+    , sendDocumentRequest
+    , sendStickerRequest
+    , sendVideoRequest
+    , sendVoiceRequest
+    , sendLocationRequest
+    , sendVenueRequest
+    , sendContactRequest
+    , sendChatActionRequest
+    , answerInlineQueryRequest
+    , answerCallbackQueryRequest
+    , replyKeyboardMarkup
+    , replyKeyboardHide
+    , forceReply
+    , editMessageTextRequest
+    , editMessageCaptionRequest
+    , editMessageReplyMarkupRequest
     ) where
 
 import           Data.Aeson
@@ -390,11 +409,11 @@ instance FromJSON ReplyKeyboard where
 replyKeyboardMarkup :: [[KeyboardButton]] -> ReplyKeyboard
 replyKeyboardMarkup keyboard = ReplyKeyboardMarkup keyboard Nothing Nothing Nothing
 
-replyKeyboardHide :: Bool -> ReplyKeyboard
-replyKeyboardHide hide = ReplyKeyboardHide hide Nothing
+replyKeyboardHide :: ReplyKeyboard
+replyKeyboardHide = ReplyKeyboardHide True Nothing
 
-forceReply :: Bool -> ReplyKeyboard
-forceReply force = ForceReply force Nothing
+forceReply :: ReplyKeyboard
+forceReply = ForceReply True Nothing
 
 data EditMessageTextRequest = EditMessageTextRequest
   {

--- a/src/Web/Telegram/API/Bot/Requests.hs
+++ b/src/Web/Telegram/API/Bot/Requests.hs
@@ -28,6 +28,8 @@ module Web.Telegram.API.Bot.Requests
     , EditMessageTextRequest         (..)
     , EditMessageCaptionRequest      (..)
     , EditMessageReplyMarkupRequest  (..)
+     -- * Functions
+    , sendMessageRequest
     ) where
 
 import           Data.Aeson
@@ -40,6 +42,7 @@ import           GHC.Generics
 import           GHC.TypeLits
 import           Web.Telegram.API.Bot.JsonExt
 import           Web.Telegram.API.Bot.Data
+
 
 -- | This object represents request for 'sendMessage'
 data SendMessageRequest = SendMessageRequest
@@ -59,6 +62,9 @@ instance ToJSON SendMessageRequest where
 instance FromJSON SendMessageRequest where
   parseJSON = parseJsonDrop 8
 
+sendMessageRequest :: Text -> Text -> SendMessageRequest
+sendMessageRequest chatId text = SendMessageRequest chatId text Nothing Nothing Nothing Nothing Nothing
+
 -- | This object represents request for 'forwardMessage'
 data ForwardMessageRequest = ForwardMessageRequest
   {
@@ -73,6 +79,9 @@ instance ToJSON ForwardMessageRequest where
 
 instance FromJSON ForwardMessageRequest where
   parseJSON = parseJsonDrop 8
+
+forwardMessageRequest :: Text -> Text -> Int -> ForwardMessageRequest
+forwardMessageRequest chatId fromChatId forwardMessageId = ForwardMessageRequest chatId fromChatId Nothing forwardMessageId
 
 -- | This object represents request for 'sendPhoto'
 data SendPhotoRequest = SendPhotoRequest
@@ -90,6 +99,9 @@ instance ToJSON SendPhotoRequest where
 
 instance FromJSON SendPhotoRequest where
   parseJSON = parseJsonDrop 6
+
+sendPhotoRequest :: Text -> Text -> SendPhotoRequest
+sendPhotoRequest chatId photo = SendPhotoRequest chatId photo Nothing Nothing Nothing Nothing
 
 -- | This object represents request for 'sendAudio'
 data SendAudioRequest = SendAudioRequest
@@ -110,6 +122,9 @@ instance ToJSON SendAudioRequest where
 instance FromJSON SendAudioRequest where
   parseJSON = parseJsonDrop 7
 
+sendAudioRequest :: Text -> Text -> SendAudioRequest
+sendAudioRequest chatId audio = SendAudioRequest chatId audio Nothing Nothing Nothing Nothing Nothing Nothing
+
 -- | This object represents request for 'sendSticker'
 data SendStickerRequest = SendStickerRequest
   {
@@ -125,6 +140,9 @@ instance ToJSON SendStickerRequest where
 
 instance FromJSON SendStickerRequest where
   parseJSON = parseJsonDrop 8
+
+sendStickerRequest :: Text -> Text -> SendStickerRequest
+sendStickerRequest chatId sticker = SendStickerRequest chatId sticker Nothing Nothing Nothing
 
 -- | This object represents request for 'sendDocument'
 data SendDocumentRequest = SendDocumentRequest
@@ -142,6 +160,9 @@ instance ToJSON SendDocumentRequest where
 
 instance FromJSON SendDocumentRequest where
   parseJSON = parseJsonDrop 9
+
+sendDocumentRequest :: Text -> Text -> SendDocumentRequest
+sendDocumentRequest chatId document = SendDocumentRequest chatId document Nothing Nothing Nothing Nothing
 
 -- | This object represents request for 'sendVideo'
 data SendVideoRequest = SendVideoRequest
@@ -161,6 +182,9 @@ instance ToJSON SendVideoRequest where
 instance FromJSON SendVideoRequest where
   parseJSON = parseJsonDrop 7
 
+sendVideoRequest :: Text -> Text -> SendVideoRequest
+sendVideoRequest chatId video = SendVideoRequest chatId video Nothing Nothing Nothing Nothing Nothing
+
 -- | This object represents request for 'sendVoice'
 data SendVoiceRequest = SendVoiceRequest
   {
@@ -178,6 +202,9 @@ instance ToJSON SendVoiceRequest where
 instance FromJSON SendVoiceRequest where
   parseJSON = parseJsonDrop 7
 
+sendVoiceRequest :: Text -> Text -> SendVoiceRequest
+sendVoiceRequest chatId voice = SendVoiceRequest chatId voice Nothing Nothing Nothing Nothing
+
 -- | This object represents request for 'sendLocation'
 data SendLocationRequest = SendLocationRequest
   {
@@ -194,6 +221,9 @@ instance ToJSON SendLocationRequest where
 
 instance FromJSON SendLocationRequest where
   parseJSON = parseJsonDrop 9
+
+sendLocationRequest :: Text -> Float -> Float -> SendLocationRequest
+sendLocationRequest chatId latitude longitude = SendLocationRequest chatId latitude longitude Nothing Nothing Nothing
 
 -- | This object represents request for 'sendVenue'
 data SendVenueRequest = SendVenueRequest
@@ -215,6 +245,9 @@ instance ToJSON SendVenueRequest where
 instance FromJSON SendVenueRequest where
   parseJSON = parseJsonDrop 7
 
+sendVenueRequest :: Text -> Float -> Float -> Text -> Text -> SendVenueRequest
+sendVenueRequest chatId latitude longitude title address = SendVenueRequest chatId latitude longitude title address Nothing Nothing Nothing Nothing
+
 -- | This object represents request for 'sendContact'
 data SendContactRequest = SendContactRequest
   {
@@ -232,6 +265,9 @@ instance ToJSON SendContactRequest where
 
 instance FromJSON SendContactRequest where
   parseJSON = parseJsonDrop 9
+
+sendContactRequest :: Text -> Text -> Text -> SendContactRequest
+sendContactRequest chatId phoneNumber firstName = SendContactRequest chatId phoneNumber firstName Nothing Nothing Nothing Nothing
 
 -- | Type of action to broadcast.
 data ChatAction = Typing
@@ -277,6 +313,8 @@ instance ToJSON SendChatActionRequest where
 instance FromJSON SendChatActionRequest where
   parseJSON = parseJsonDrop 7
 
+sendChatActionRequest :: Text -> ChatAction -> SendChatActionRequest
+sendChatActionRequest chatId action = SendChatActionRequest chatId action
 
 data AnswerInlineQueryRequest = AnswerInlineQueryRequest
   {
@@ -302,6 +340,9 @@ instance ToJSON AnswerInlineQueryRequest where
 instance FromJSON AnswerInlineQueryRequest where
   parseJSON = parseJsonDrop 6
 
+answerInlineQueryRequest :: Text -> [InlineQueryResult] -> AnswerInlineQueryRequest
+answerInlineQueryRequest queryId results = AnswerInlineQueryRequest queryId results Nothing Nothing Nothing Nothing Nothing
+
 data AnswerCallbackQueryRequest = AnswerCallbackQueryRequest
   {
     cq_callback_query_id :: Text -- ^ Unique identifier for the query to be answered
@@ -314,6 +355,9 @@ instance ToJSON AnswerCallbackQueryRequest where
 
 instance FromJSON AnswerCallbackQueryRequest where
   parseJSON = parseJsonDrop 3
+
+answerCallbackQueryRequest :: Text -> AnswerCallbackQueryRequest
+answerCallbackQueryRequest chatId = AnswerCallbackQueryRequest chatId Nothing Nothing
 
 data ReplyKeyboard =
   -- | This object represents a custom keyboard with reply options
@@ -343,6 +387,15 @@ instance ToJSON ReplyKeyboard where
 instance FromJSON ReplyKeyboard where
   parseJSON = parseJsonDrop 6
 
+replyKeyboardMarkup :: [[KeyboardButton]] -> ReplyKeyboard
+replyKeyboardMarkup keyboard = ReplyKeyboardMarkup keyboard Nothing Nothing Nothing
+
+replyKeyboardHide :: Bool -> ReplyKeyboard
+replyKeyboardHide hide = ReplyKeyboardHide hide Nothing
+
+forceReply :: Bool -> ReplyKeyboard
+forceReply force = ForceReply force Nothing
+
 data EditMessageTextRequest = EditMessageTextRequest
   {
     emt_chat_id :: Maybe Text -- ^ Required if `inline_message_id` is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`)
@@ -360,6 +413,12 @@ instance ToJSON EditMessageTextRequest where
 instance FromJSON EditMessageTextRequest where
   parseJSON = parseJsonDrop 4
 
+editMessageTextRequest :: Text -> Int -> Text -> EditMessageTextRequest
+editMessageTextRequest chatId messageId text = EditMessageTextRequest (Just chatId) (Just messageId) Nothing text Nothing Nothing Nothing
+
+editInlineMessageTextRequest :: Text -> Text -> EditMessageTextRequest
+editInlineMessageTextRequest inlineMessageId text = EditMessageTextRequest Nothing Nothing (Just inlineMessageId) text Nothing Nothing Nothing
+
 data EditMessageCaptionRequest = EditMessageCaptionRequest
   {
     emc_chat_id :: Maybe Text -- ^ Required if `inline_message_id` is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`)
@@ -375,6 +434,12 @@ instance ToJSON EditMessageCaptionRequest where
 instance FromJSON EditMessageCaptionRequest where
   parseJSON = parseJsonDrop 4
 
+editMessageCaptionRequest :: Text -> Int -> Maybe Text -> EditMessageCaptionRequest
+editMessageCaptionRequest chatId messageId caption = EditMessageCaptionRequest (Just chatId) (Just messageId) Nothing caption Nothing
+
+editInlineMessageCaptionRequest :: Text -> Maybe Text -> EditMessageCaptionRequest
+editInlineMessageCaptionRequest inlineMessageId caption = EditMessageCaptionRequest Nothing Nothing (Just inlineMessageId) caption Nothing
+
 data EditMessageReplyMarkupRequest = EditMessageReplyMarkupRequest
   {
     emrm_chat_id :: Maybe Text -- ^ Required if `inline_message_id` is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`)
@@ -388,3 +453,9 @@ instance ToJSON EditMessageReplyMarkupRequest where
 
 instance FromJSON EditMessageReplyMarkupRequest where
   parseJSON = parseJsonDrop 5
+
+editMessageReplyMarkupRequest :: Text -> Int -> Maybe InlineKeyboardMarkup -> EditMessageReplyMarkupRequest
+editMessageReplyMarkupRequest chatId messageId keyboard = EditMessageReplyMarkupRequest (Just chatId) (Just messageId) Nothing keyboard
+
+editInlineMessageReplyMarkupRequest :: Text -> Maybe InlineKeyboardMarkup -> EditMessageReplyMarkupRequest
+editInlineMessageReplyMarkupRequest inlineMessageId keyboard = EditMessageReplyMarkupRequest Nothing Nothing (Just inlineMessageId) keyboard

--- a/test/MainSpec.hs
+++ b/test/MainSpec.hs
@@ -33,19 +33,22 @@ spec token chatId botName = do
 
   describe "/sendMessage" $ do
     it "should send message" $ do
-      res <- sendMessage token (SendMessageRequest chatId "test message" Nothing Nothing Nothing Nothing Nothing) manager
+      res <- sendMessage token (sendMessageRequest chatId "test message") manager
       success res 
       let Right MessageResponse { message_result = m } = res
       (text m) `shouldBe` (Just "test message")
 
     it "should return error message" $ do
-      res <- sendMessage token (SendMessageRequest "" "test message" Nothing Nothing Nothing Nothing Nothing) manager
+      res <- sendMessage token (sendMessageRequest "" "test message") manager
       nosuccess res
       let Left FailureResponse { responseStatus = Status { statusMessage = msg } } = res
       msg `shouldBe` "Bad Request"
 
     it "should send message markdown" $ do
-      res <- sendMessage token (SendMessageRequest chatId "text *bold* _italic_ [github](github.com/klappvisor/telegram-api)" (Just Markdown) Nothing Nothing Nothing Nothing) manager
+      let request = (sendMessageRequest chatId "text *bold* _italic_ [github](github.com/klappvisor/telegram-api)") {
+          message_parse_mode = Just Markdown
+        }
+      res <- sendMessage token request manager
       success res
       let Right MessageResponse { message_result = m } = res
       (text m) `shouldBe` (Just "text bold italic github")
@@ -73,7 +76,7 @@ spec token chatId botName = do
 
   describe "/forwardMessage" $ do
     it "should forward message" $ do
-      res <- forwardMessage token (ForwardMessageRequest chatId chatId Nothing 123) manager
+      res <- forwardMessage token (ForwardMessageRequest chatId chatId Nothing 123000) manager
       nosuccess res
       let Left FailureResponse { responseStatus = Status { statusMessage = msg } } = res
       msg `shouldBe` "Bad Request"

--- a/test/MainSpec.hs
+++ b/test/MainSpec.hs
@@ -54,77 +54,101 @@ spec token chatId botName = do
       (text m) `shouldBe` (Just "text bold italic github")
 
     it "should set keyboard" $ do
-      let kbA = KeyboardButton "A" Nothing Nothing
-          kbB = KeyboardButton "B" Nothing Nothing
-          kbC = KeyboardButton "C" Nothing Nothing
-      res <- sendMessage token (SendMessageRequest chatId "set keyboard" Nothing Nothing Nothing Nothing (Just (ReplyKeyboardMarkup [[kbA, kbB], [kbC]] Nothing Nothing Nothing))) manager
+      let kbA = keyboardButton "A"
+          kbB = keyboardButton "B"
+          kbC = keyboardButton "C"
+      let message = (sendMessageRequest chatId "set keyboard") {
+        message_reply_markup = Just $ replyKeyboardMarkup [[kbA, kbB, kbC]]
+      }
+      res <- sendMessage token message manager
       success res
       let Right MessageResponse { message_result = m } = res
       (text m) `shouldBe` (Just "set keyboard")
 
     it "should remove keyboard" $ do
-      res <- sendMessage token (SendMessageRequest chatId "remove keyboard" Nothing Nothing Nothing Nothing (Just (ReplyKeyboardHide True Nothing))) manager
+      let message = (sendMessageRequest chatId "remove keyboard") {
+        message_reply_markup = Just replyKeyboardHide
+      }
+      res <- sendMessage token message manager
       success res
       let Right MessageResponse { message_result = m } = res
       (text m) `shouldBe` (Just "remove keyboard")
 
     it "should force reply" $ do
-      res <- sendMessage token (SendMessageRequest chatId "force reply" Nothing Nothing Nothing Nothing (Just (ForceReply True Nothing))) manager
+      let message = (sendMessageRequest chatId "force reply") {
+        message_reply_markup = Just forceReply
+      }
+      res <- sendMessage token message manager
       success res
       let Right MessageResponse { message_result = m } = res
       (text m) `shouldBe` (Just "force reply")
 
   describe "/forwardMessage" $ do
     it "should forward message" $ do
-      res <- forwardMessage token (ForwardMessageRequest chatId chatId Nothing 123000) manager
+      res <- forwardMessage token (forwardMessageRequest chatId chatId 123000) manager
       nosuccess res
       let Left FailureResponse { responseStatus = Status { statusMessage = msg } } = res
       msg `shouldBe` "Bad Request"
 
   describe "/sendPhoto" $ do
     it "should return error message" $ do
+      let photo = (sendPhotoRequest "" "photo_id") {
+        photo_caption = Just "photo caption"
+      }
       Left FailureResponse { responseStatus = Status { statusMessage = msg } } <-
-        sendPhoto token (SendPhotoRequest "" "photo_id" (Just "photo caption") Nothing Nothing Nothing) manager
+        sendPhoto token photo manager
       msg `shouldBe` "Bad Request"
     it "should send photo" $ do
-     Right MessageResponse { message_result = Message { caption = Just cpt } } <-
-       sendPhoto token (SendPhotoRequest chatId catPic (Just "photo caption") Nothing Nothing Nothing) manager
-     cpt `shouldBe` "photo caption"
+      let photo = (sendPhotoRequest chatId catPic) {
+        photo_caption = Just "photo caption"
+      }
+      Right MessageResponse { message_result = Message { caption = Just cpt } } <-
+        sendPhoto token photo manager
+      cpt `shouldBe` "photo caption"
 
   describe "/sendAudio" $ do
     it "should return error message" $ do
+      let audio = (sendAudioRequest "" "audio_id") {
+        _audio_performer = Just "performer"
+      , _audio_title = Just "title"
+      }
       Left FailureResponse { responseStatus = Status { statusMessage = msg } } <-
-        sendAudio token (SendAudioRequest "" "audio_id" Nothing (Just "performer") (Just "title") Nothing Nothing Nothing) manager
+        sendAudio token audio manager
       msg `shouldBe` "Bad Request"
     it "should send audio" $ do
+      let audio = sendAudioRequest chatId "BQADBAADAQQAAiBOnQHThzc4cz1-IwI"
       Right MessageResponse { message_result = Message { audio = Just Audio { audio_title = Just title } } } <-
-        sendAudio token (SendAudioRequest chatId "BQADBAADAQQAAiBOnQHThzc4cz1-IwI" Nothing Nothing Nothing Nothing Nothing Nothing) manager
+        sendAudio token audio manager
       title `shouldBe` "The Nutcracker Suite - Act II, No.12. Pas de Deux variations"
 
   describe "/sendSticker" $ do
     it "should send sticker" $ do
+      let sticker = sendStickerRequest chatId "BQADAgADGgADkWgMAAGXlYGBiM_d2wI"
       Right MessageResponse { message_result = Message { sticker = Just sticker } } <-
-        sendSticker token (SendStickerRequest chatId "BQADAgADGgADkWgMAAGXlYGBiM_d2wI" Nothing Nothing Nothing) manager
+        sendSticker token sticker manager
       (sticker_file_id sticker) `shouldBe` "BQADAgADGgADkWgMAAGXlYGBiM_d2wI"
 
   describe "/sendLocation" $ do
     it "should send location" $ do
+      let location = sendLocationRequest chatId 52.38 4.9
       Right MessageResponse { message_result = Message { location = Just loc } } <-
-        sendLocation token (SendLocationRequest chatId 52.38 4.9 Nothing Nothing Nothing) manager
+        sendLocation token location manager
       (latitude loc) `shouldSatisfy` (liftM2 (&&) (> 52) (< 52.4))
       (longitude loc) `shouldSatisfy` (liftM2 (&&) (> 4.89) (< 5))
 
   describe "/sendVenue" $ do
     it "should send a venue" $ do
+      let venue = sendVenueRequest chatId 52.38 4.9 "Amsterdam Centraal" "Amsterdam"
       Right MessageResponse { message_result = Message { location = Just loc } } <-
-        sendVenue token (SendVenueRequest chatId 52.38 4.9 "Amsterdam Centraal" "Amsterdam" Nothing Nothing Nothing Nothing) manager
+        sendVenue token venue manager
       (latitude loc) `shouldSatisfy` (liftM2 (&&) (> 52) (< 52.4))
       (longitude loc) `shouldSatisfy` (liftM2 (&&) (> 4.89) (< 5))
 
   describe "/sendContact" $ do
     it "should send a contact" $ do
+      let contact = sendContactRequest chatId "06-18035176" "Hilbert"
       Right MessageResponse { message_result = Message { contact = Just con } } <-
-        sendContact token (SendContactRequest chatId "06-18035176" "Hilbert" Nothing Nothing Nothing Nothing) manager
+        sendContact token contact manager
       -- Telegram seems to remove any non numeric characters from the sent phone number (at least it removed my '-')
       (contact_phone_number con) `shouldBe` "0618035176"
       (contact_first_name con) `shouldBe` "Hilbert"
@@ -179,19 +203,23 @@ spec token chatId botName = do
 
   describe "/editTextMessage" $ do
     it "should edit message" $ do
-      let originalMessage = SendMessageRequest chatId "veritas" Nothing Nothing Nothing Nothing Nothing
+      let originalMessage = sendMessageRequest chatId "veritas"
       Right MessageResponse { message_result = Message { message_id = msg_id, text = Just txt } } <-
         sendMessage token originalMessage manager
+      let editRequest = editMessageTextRequest chatId msg_id $ "edited " <> txt
       Right MessageResponse { message_result = Message { text = txt' } } <-
-        editMessageText token (EditMessageTextRequest (Just chatId) (Just msg_id) Nothing ("edited " <> txt) Nothing Nothing Nothing) manager
+        editMessageText token editRequest manager
       txt' `shouldBe` Just "edited veritas"
 
     it "should edit caption" $ do
-      let originalMessage = SendPhotoRequest chatId catPic (Just "cat picture") Nothing Nothing Nothing
+      let originalMessage = (sendPhotoRequest chatId catPic) {
+        photo_caption = Just "cat picture"
+      }
       Right MessageResponse { message_result = Message { message_id = msg_id, caption = Just cpt } } <-
         sendPhoto token originalMessage manager
+      let editRequest = editMessageCaptionRequest chatId msg_id $ Just $ "edited " <> cpt
       Right MessageResponse { message_result = Message { caption = Just cpt' } } <-
-        editMessageCaption token (EditMessageCaptionRequest (Just chatId) (Just msg_id) Nothing (Just ("edited " <> cpt)) Nothing) manager
+        editMessageCaption token editRequest manager
       cpt' `shouldBe` "edited cat picture"
 
     -- it "should edit caption" $ do ... after inline query tests are on place


### PR DESCRIPTION
Many request data records have lots of optional fields which usually redundant. 
In order to solve this issue new way of creating request is introduced:

Previously supported: 
```haskell
let request = SendMessageRequest "chatId" "text" Nothing (Just True) Nothing Nothing Nothing
```
Newly added:
only with required fields:
```haskell
let request = sendMessageRequest "chatId" "text"
```
with optional fields
```haskell
let request = (sendMessageRequest "chatId" "text") {
  message_disable_notification = Just True
}
```