### PR TITLE
Add command line option parsing with optparser-applicative to tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Contributions are welcome!
 5. ??????
 6. PROFIT
 
+Bear in mind that the CI build may fail since the necessary environment
+variables (`$BOT_TOKEN`, `$CHAT_ID` and `$BOT_NAME`) aren't exported when a fork
+starts the build.
+
 You can use `stack` to build project
 
 ```

--- a/README.md
+++ b/README.md
@@ -108,14 +108,22 @@ stack build
 To run test you have to create your own bot. Go to [BotFather](https://telegram.me/botfather) and create the bot. As the result you will have private bot's access token. Keep it safe!
 
 ```
-stack test --test-arguments "$BOT_TOKEN $CHAT_ID $BOT_NAME"
+stack test --test-arguments "-t BOT_TOKEN -c CHAT_ID -b BOT_NAME -- HSPEC_ARGS"
 ```
 
 where
 
-* `$BOT_TOKEN` is token obtained from BotFather
-* `$CHAT_ID` can be id of your chat with your bot. Send some message to this chat in Telegram and do `curl "https://api.telegram.org/bot<replace_with_token>/getUpdates"`, you have to parse some JSON with your brain ;-) or any other suitable tool and you will find chat id there.
-* `$BOT_NAME` name of your bot
+* `BOT_TOKEN` is the token obtained from BotFather
+* `CHAT_ID` can be id of your chat with your bot. Send some messages to this chat in Telegram and do `curl "https://api.telegram.org/bot<replace_with_token>/getUpdates"`, you'll have to parse some JSON with your brain ;-) or any other suitable tool and you will find chat id there.
+* `BOT_NAME` is the name of your bot
+* `HSPEC_ARGS` are the normal `hspec` arguments you can find [here][hspec-args]
+
+The help option is availabe for the tests and for hspec:
+
+``` 
+stack test --test-arguments "-h"
+stack test --test-arguments "-t BOT_TOKEN -c CHAT_ID -v BOT_NAME -- -h"
+```
 
 Note: Inline Spec is disabled for now...
 
@@ -158,3 +166,4 @@ If everything is fine after running the tests you will receive a few new message
 
 [telegram-bot-api]: https://core.telegram.org/bots/api
 [servant]: https://haskell-servant.github.io/
+[hspec-args]: https://hspec.github.io/running-specs.html

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ dependencies:
 
 test:
   override:
-    - stack test --test-arguments "$BOT_TOKEN $CHAT_ID $BOT_NAME"
+    - stack test --test-arguments "--token $BOT_TOKEN --chatid $CHAT_ID --botname $BOT_NAME"
 
 deployment:
   master:

--- a/telegram-api.cabal
+++ b/telegram-api.cabal
@@ -42,14 +42,16 @@ test-suite telegram-api-test
   other-modules:       MainSpec
                      , InlineSpec
   build-depends:       base
-                     , text
+                     , ansi-wl-pprint
                      , http-client
                      , http-client-tls
+                     , http-types
                      , hspec
+                     , optparse-applicative
                      , servant
                      , servant-client
                      , telegram-api
-                     , http-types
+                     , text
                      , transformers
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -19,7 +19,7 @@ data Options = Options
     opt_token     :: String   -- ^ Bot token from BotFather
   , opt_chatId    :: String   -- ^ Id of a chat or of your bot
   , opt_botName   :: String   -- ^ Bot name
-  , opt_hSpecOtps :: Maybe [String] -- ^ Command line options to pass to hSpec
+  , opt_hSpecOpts :: Maybe [String] -- ^ Command line options to pass to hSpec
   }
 
 options :: Parser Options
@@ -49,7 +49,7 @@ main = do
     let token = Token ("bot" <> T.pack opt_token)
         chatId = T.pack opt_chatId
         botName = T.pack opt_botName
-        hspecArgs = fromMaybe [] opt_hSpecOtps
+        hspecArgs = fromMaybe [] opt_hSpecOpts
     withArgs hspecArgs $ hspec (runSpec' token chatId botName)
     where opts = info (helper <*> options)
             ( fullDesc

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -3,12 +3,14 @@
 
 module Main (main) where
 
+import           Control.Monad                (when)
 import           Data.Maybe                   (fromMaybe)
 import           Data.Text                    (Text)
 import qualified Data.Text                    as T
 import qualified MainSpec
 import           Options.Applicative
-import           System.Environment           (withArgs)
+import           System.Environment           (getArgs, withArgs)
+import           System.Exit                  (exitSuccess)
 import           Test.Hspec
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
 import           Web.Telegram.API.Bot
@@ -45,6 +47,12 @@ options = Options
 
 main :: IO ()
 main = do
+    args <- getArgs
+    -- If called with -t -b -c with no actual arguments
+    -- don't test but return success.
+    when (length args == 3) $ do
+      putStrLn "Empty options, exiting with success"
+      exitSuccess
     Options{..} <- execParser opts
     let token = Token ("bot" <> T.pack opt_token)
         chatId = T.pack opt_chatId


### PR DESCRIPTION
Now it is possibile to also use the hspec options.