### PR TITLE
Fix building with cabal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .cabal-sandbox/
 cabal.sandbox.config
 *.iml
+dist
+dist-newstyle

--- a/telegram-api.cabal
+++ b/telegram-api.cabal
@@ -37,7 +37,7 @@ library
                      , aeson == 1.0.*
                      , either
                      , http-api-data
-                     , http-client
+                     , http-client >= 0.4 && < 0.5
                      , servant >= 0.7 && <0.9
                      , servant-client >= 0.7 && <0.9
                      , text
@@ -61,7 +61,7 @@ test-suite telegram-api-test
                      , aeson == 1.0.*
                      , hjpath
                      , ansi-wl-pprint
-                     , http-client
+                     , http-client >= 0.4 && < 0.5
                      , http-client-tls
                      , http-types
                      , hspec

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -3,6 +3,7 @@
 
 module Main (main) where
 
+import           Data.Monoid                  ((<>))
 import           Data.Maybe                   (fromMaybe)
 import           Data.Text                    (Text)
 import qualified Data.Text                    as T


### PR DESCRIPTION
The current version on hackage does not compile with cabal.

Without upper bounds on `http-client` cabal tries to use the `0.5` version, but the `checkStatus `function has been renamed to `checkResponse` and the type signature also changed. ([http-client changelog](http://hackage.haskell.org/package/http-client/changelog ))

Since stack is still stuck on version `0.4`, even the nightly, I think it's better to put an upper bound for now and once a `0.5` version is in a stack lts it can be relaxed and updated to `>= 0.5` so that is uses the new version.

