### PR TITLE
Switch to http-client-0.5.*

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ dependencies:
 
 test:
   override:
-    - echo $CIRCLE_PULL_REQUEST ; if [[ ! -z $CIRCLE_PULL_REQUEST ]] ; then stack test; else stack test --test-arguments "--integration --token $BOT_TOKEN --chatid $CHAT_ID --botname $BOT_NAME"; fi
+    - echo $CI_PULL_REQUEST ; if [[ ! -z $CI_PULL_REQUEST ]] ; then stack test; else stack test --test-arguments "--integration --token $BOT_TOKEN --chatid $CHAT_ID --botname $BOT_NAME"; fi
 
 deployment:
   master:

--- a/src/Servant/Client/MultipartFormData.hs
+++ b/src/Servant/Client/MultipartFormData.hs
@@ -61,7 +61,7 @@ performRequest' reqToRequest' reqMethod req manager reqHost = do
   partialRequest <- liftIO $ reqToRequest' req reqHost
 
   let request = partialRequest { Client.method = reqMethod
-                               , checkStatus = \ _status _headers _cookies -> Nothing
+                               , checkResponse = \ _request _response -> return ()
                                }
 
   eResponse <- liftIO $ catchConnectionError $ Client.httpLbs request manager

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,8 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-#resolver: nightly-2016-05-12
-resolver: lts-7.1
+resolver: nightly-2016-11-19
+#resolver: lts-7.1
 
 # Local packages, usually specified by relative directory name
 packages:
@@ -10,12 +10,12 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
- - servant-0.9
- - servant-client-0.9
- - aeson-1.0.0.0
- - http-api-data-0.3.1
- - hjpath-3.0.1
- - hjson-1.3.2
+- hjpath-3.0.1
+- hjson-1.3.2
+  # - servant-0.9
+  # - servant-client-0.9
+  # - aeson-1.0.0.0
+  # - http-api-data-0.3.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/telegram-api.cabal
+++ b/telegram-api.cabal
@@ -36,7 +36,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , aeson == 1.0.*
                      , http-api-data
-                     , http-client >= 0.4 && < 0.5
+                     , http-client >= 0.5 && < 0.6
                      , servant >= 0.9 && <0.10
                      , servant-client >= 0.9 && <0.10
                      , mtl >= 2.2 && < 2.3
@@ -61,7 +61,7 @@ test-suite telegram-api-test
                      , aeson == 1.0.*
                      , hjpath
                      , ansi-wl-pprint
-                     , http-client >= 0.4 && < 0.5
+                     , http-client >= 0.5 && < 0.6
                      , http-client-tls
                      , http-types
                      , hspec


### PR DESCRIPTION
If needed I can add CPP to allow `http-client-0.4.*` too.

I would love to see this fix released and added to Stackage. Thanks!