### PR TITLE
Bump aeson upper bound to include 1.1.*

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: nightly-2016-11-19
+resolver: nightly-2017-02-09
 #resolver: lts-7.1
 
 # Local packages, usually specified by relative directory name
@@ -10,12 +10,7 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-- hjpath-3.0.1
-- hjson-1.3.2
-  # - servant-0.9
-  # - servant-client-0.9
-  # - aeson-1.0.0.0
-  # - http-api-data-0.3.1
+- aeson-1.1.0.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/telegram-api.cabal
+++ b/telegram-api.cabal
@@ -41,7 +41,7 @@ library
                      , Web.Telegram.API.Bot.API.Core
                      , Servant.Client.MultipartFormData
   build-depends:       base >= 4.7 && < 5
-                     , aeson == 1.0.*
+                     , aeson >= 1.0 && < 1.2
                      , http-api-data
                      , http-client >= 0.5 && < 0.6
                      , servant >= 0.9 && <0.10


### PR DESCRIPTION
In order to resolve https://github.com/fpco/stackage/issues/2177.