### PR TITLE
Servant-0.11 compatibility

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-8.12
+resolver: lts-9.0
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/telegram-api.cabal
+++ b/telegram-api.cabal
@@ -46,8 +46,8 @@ library
                      , aeson >= 1.0 && < 1.3
                      , http-api-data
                      , http-client >= 0.5 && < 0.6
-                     , servant >= 0.9 && <0.11
-                     , servant-client >= 0.9 && <0.11
+                     , servant >= 0.11 && <0.12
+                     , servant-client >= 0.11 && <0.12
                      , mtl >= 2.2 && < 2.3
                      , text
                      , transformers

--- a/telegram-api.cabal
+++ b/telegram-api.cabal
@@ -1,5 +1,5 @@
 name:                telegram-api
-version:             0.6.3.0
+version:             0.7.0.0
 synopsis:            Telegram Bot API bindings
 description:         High-level bindings to the Telegram Bot API
 homepage:            http://github.com/klappvisor/haskell-telegram-api#readme


### PR DESCRIPTION
This pull request is for issue #100. There is only one meaningful change, an adoption of new parameter in data constructor FailureResponse.

This change is incompatible with previous versions of servant, therefore I assume that version bump is required. I mark it as version 0.7.0.0 but I am not sure what the policy is. So, feel free to change it according to your rules.

The version can be compiled against LTS-9.0 with GHC 8.0.2 and nightly-2017-08-11 with GHC 8.2.1.