### PR TITLE
Bump servant version to 0.12.1

### DIFF
--- a/src/Servant/Client/MultipartFormData.hs
+++ b/src/Servant/Client/MultipartFormData.hs
@@ -22,7 +22,10 @@ import           Data.ByteString.Lazy                  hiding (elem, filter,
                                                         map, null, pack, any)
 import           Data.Proxy
 import           Data.Foldable (toList)
+import qualified Data.List.NonEmpty                    as NonEmpty
 import           Data.String.Conversions
+import qualified Data.Sequence                         as Sequence
+import           Data.Text                             (pack)
 import           Data.Typeable                         (Typeable)
 import           Network.HTTP.Client                   hiding (Proxy, path)
 import qualified Network.HTTP.Client                   as Client
@@ -33,9 +36,10 @@ import qualified Network.HTTP.Types                    as H
 import qualified Network.HTTP.Types.Header             as HTTP
 import           Servant.API
 import           Servant.Client
-import           Servant.Common.Req                    (Req, UrlReq (..), ClientEnv (..),
-                                                        catchConnectionError,
-                                                        reqAccept, reqToRequest)
+import qualified Servant.Client.Core                   as Core
+import           Servant.Client.Internal.HttpClient    (catchConnectionError, clientResponseToReponse,
+                                                        requestToClientRequest)
+
 -- | A type that can be converted to a multipart/form-data value.
 class ToMultipartFormData a where
   -- | Convert a Haskell value to a multipart/form-data-friendly intermediate type.
@@ -45,59 +49,60 @@ class ToMultipartFormData a where
 data MultipartFormDataReqBody a
     deriving (Typeable)
 
-instance (ToMultipartFormData b, MimeUnrender ct a, cts' ~ (ct ': cts)
-  ) => HasClient (MultipartFormDataReqBody b :> Post cts' a) where
-  type Client (MultipartFormDataReqBody b :> Post cts' a)
-    = b -> ClientM a
-  clientWithRoute Proxy req reqData =
-    let reqToRequest' req' baseurl' = do
-          requestWithoutBody <- reqToRequest req' baseurl'
+instance (Core.RunClient m, ToMultipartFormData b, MimeUnrender ct a, cts' ~ (ct ': cts)
+  ) => HasClient m (MultipartFormDataReqBody b :> Post cts' a) where
+  type Client m (MultipartFormDataReqBody b :> Post cts' a) = b-> ClientM a
+  clientWithRoute _pm Proxy req reqData =
+    let requestToClientRequest' req' baseurl' = do
+          let requestWithoutBody = requestToClientRequest baseurl' req'
           formDataBody (toMultipartFormData reqData) requestWithoutBody
-    in snd <$> performRequestCT' reqToRequest' (Proxy :: Proxy ct) H.methodPost req
+    in snd <$> performRequestCT' requestToClientRequest' (Proxy :: Proxy ct) H.methodPost req
 
--- copied `performRequest` from servant-0.11, then modified so it takes a variant of `reqToRequest`
+-- copied `performRequest` from servant-0.11, then modified so it takes a variant of `requestToClientRequest`
 -- as an argument.
-performRequest' :: (Req -> BaseUrl -> IO Request)
-               -> Method -> Req
+performRequest' :: (Core.Request -> BaseUrl -> IO Request)
+               -> Method -> Core.Request
                -> ClientM ( Int, ByteString, MediaType
-                          , [HTTP.Header], Response ByteString)
-performRequest' reqToRequest' reqMethod req = do
+                          , [HTTP.Header], Client.Response ByteString)
+performRequest' requestToClientRequest' reqMethod req = do
   m <- asks manager
   reqHost <- asks baseUrl
-  partialRequest <- liftIO $ reqToRequest' req reqHost
+  partialRequest <- liftIO $ requestToClientRequest' req reqHost
 
   let request = partialRequest { Client.method = reqMethod }
 
   eResponse <- liftIO $ catchConnectionError $ Client.httpLbs request m
   case eResponse of
     Left err ->
-      throwError . ConnectionError $ SomeException err
+      throwError . ConnectionError $ pack $ show err
 
     Right response -> do
       let status = Client.responseStatus response
           body = Client.responseBody response
           hdrs = Client.responseHeaders response
           status_code = statusCode status
+          coreResponse = clientResponseToReponse response
       ct <- case lookup "Content-Type" $ Client.responseHeaders response of
                  Nothing -> pure $ "application"//"octet-stream"
                  Just t -> case parseAccept t of
-                   Nothing -> throwError $ InvalidContentTypeHeader (cs t) body
+                   Nothing -> throwError $ InvalidContentTypeHeader coreResponse
                    Just t' -> pure t'
       unless (status_code >= 200 && status_code < 300) $
-        throwError $ FailureResponse (UrlReq reqHost req) status ct body
+        throwError $ FailureResponse coreResponse
       return (status_code, body, ct, hdrs, response)
 
--- copied `performRequestCT` from servant-0.11, then modified so it takes a variant of `reqToRequest`
+-- copied `performRequestCT` from servant-0.11, then modified so it takes a variant of `requestToClientRequest`
 -- as an argument.
-performRequestCT' :: MimeUnrender ct result => 
-    (Req -> BaseUrl -> IO Request)
-    -> Proxy ct -> Method -> Req
+performRequestCT' :: MimeUnrender ct result =>
+    (Core.Request -> BaseUrl -> IO Request)
+    -> Proxy ct -> Method -> Core.Request
     -> ClientM ([HTTP.Header], result)
-performRequestCT' reqToRequest' ct reqMethod req = do
+performRequestCT' requestToClientRequest' ct reqMethod req = do
   let acceptCTS = contentTypes ct
   (_status, respBody, respCT, hdrs, _response) <-
-    performRequest' reqToRequest' reqMethod (req { reqAccept = toList acceptCTS }) 
-  unless (any (matches respCT) acceptCTS) $ throwError $ UnsupportedContentType respCT respBody
+    performRequest' requestToClientRequest' reqMethod (req { Core.requestAccept = Sequence.fromList $ NonEmpty.toList acceptCTS })
+  let coreResponse = clientResponseToReponse _response
+  unless (any (matches respCT) acceptCTS) $ throwError $ UnsupportedContentType respCT coreResponse
   case mimeUnrender ct respBody of
-    Left err -> throwError $ DecodeFailure err respCT respBody
+    Left err -> throwError $ DecodeFailure (pack err) coreResponse
     Right val -> return (hdrs, val)

--- a/src/Web/Telegram/API/Bot/API/Chats.hs
+++ b/src/Web/Telegram/API/Bot/API/Chats.hs
@@ -39,7 +39,7 @@ import           Data.Proxy
 import           Data.Text                        (Text)
 import           Network.HTTP.Client              (Manager)
 import           Servant.API
-import           Servant.Client
+import           Servant.Client            hiding (Response)
 import           Servant.Client.MultipartFormData
 import           Web.Telegram.API.Bot.API.Core
 import           Web.Telegram.API.Bot.Requests

--- a/src/Web/Telegram/API/Bot/API/Edit.hs
+++ b/src/Web/Telegram/API/Bot/API/Edit.hs
@@ -27,7 +27,7 @@ module Web.Telegram.API.Bot.API.Edit
 import           Data.Proxy
 import           Network.HTTP.Client            (Manager)
 import           Servant.API
-import           Servant.Client
+import           Servant.Client          hiding (Response)
 import           Web.Telegram.API.Bot.API.Core
 import           Web.Telegram.API.Bot.Requests
 import           Web.Telegram.API.Bot.Responses

--- a/src/Web/Telegram/API/Bot/API/Messages.hs
+++ b/src/Web/Telegram/API/Bot/API/Messages.hs
@@ -57,7 +57,7 @@ import           Data.Proxy
 import           Data.Text                        (Text)
 import           Network.HTTP.Client              (Manager)
 import           Servant.API
-import           Servant.Client
+import           Servant.Client            hiding (Response)
 import           Servant.Client.MultipartFormData
 import           Web.Telegram.API.Bot.API.Core
 import           Web.Telegram.API.Bot.Data

--- a/src/Web/Telegram/API/Bot/API/Stickers.hs
+++ b/src/Web/Telegram/API/Bot/API/Stickers.hs
@@ -21,7 +21,7 @@ module Web.Telegram.API.Bot.API.Stickers
 import           Data.Proxy
 import           Data.Text                        (Text)
 import           Servant.API
-import           Servant.Client
+import           Servant.Client            hiding (Response)
 import           Servant.Client.MultipartFormData
 import           Web.Telegram.API.Bot.API.Core
 import           Web.Telegram.API.Bot.Data

--- a/src/Web/Telegram/API/Bot/API/Updates.hs
+++ b/src/Web/Telegram/API/Bot/API/Updates.hs
@@ -25,7 +25,7 @@ import           Data.Proxy
 import           Data.Text                        (Text, empty)
 import           Network.HTTP.Client              (Manager)
 import           Servant.API
-import           Servant.Client
+import           Servant.Client            hiding (Response)
 import           Servant.Client.MultipartFormData
 import           Web.Telegram.API.Bot.API.Core
 import           Web.Telegram.API.Bot.Requests

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,6 +11,9 @@ packages:
 extra-deps:
 - hjson-1.3.2
 - hjpath-3.0.1
+- servant-0.12.1
+- servant-client-0.12.0.1
+- servant-client-core-0.12
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/telegram-api.cabal
+++ b/telegram-api.cabal
@@ -47,10 +47,12 @@ library
                      , Servant.Client.MultipartFormData
   build-depends:       base >= 4.7 && < 5
                      , aeson >= 1.0 && < 1.3
+                     , containers >= 0.5 && < 0.6
                      , http-api-data
                      , http-client >= 0.5 && < 0.6
-                     , servant >= 0.11 && <0.12
-                     , servant-client >= 0.11 && <0.12
+                     , servant >= 0.12 && < 0.13
+                     , servant-client >= 0.12 && < 0.13
+                     , servant-client-core >= 0.12 && < 0.13
                      , mtl >= 2.2 && < 2.3
                      , text
                      , transformers
@@ -82,8 +84,9 @@ test-suite telegram-api-test
                      , http-types
                      , hspec
                      , optparse-applicative
-                     , servant >= 0.11 && <0.12
-                     , servant-client >= 0.11 && <0.12
+                     , servant >= 0.12 && <0.13
+                     , servant-client >= 0.12 && <0.13
+                     , servant-client-core >= 0.12 && < 0.13
                      , telegram-api
                      , http-types
                      , filepath

--- a/test/InlineSpec.hs
+++ b/test/InlineSpec.hs
@@ -48,6 +48,6 @@ message_content = InputTextMessageContent "test message content" Nothing Nothing
 
 inline_article = InlineQueryResultArticle "2131341" (Just "text article content") (Just message_content) Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 inline_photo = InlineQueryResultPhoto "1430810" "http://vignette3.wikia.nocookie.net/victorious/images/f/f8/NyanCat.jpg" (Just "http://vignette3.wikia.nocookie.net/victorious/images/f/f8/NyanCat.jpg") Nothing Nothing Nothing Nothing Nothing Nothing Nothing
-inline_gif = InlineQueryResultGif "131231234" "https://media.giphy.com/media/zEO5eq3ZsEwbS/giphy.gif" Nothing Nothing (Just "https://media.giphy.com/media/zEO5eq3ZsEwbS/100.gif") Nothing Nothing Nothing Nothing
-inline_mpeg = InlineQueryResultMpeg4Gif "131251234" "https://media.giphy.com/media/zEO5eq3ZsEwbS/giphy.gif" Nothing Nothing (Just "https://media.giphy.com/media/zEO5eq3ZsEwbS/100.gif") Nothing Nothing Nothing Nothing
+inline_gif = InlineQueryResultGif "131231234" "https://media.giphy.com/media/zEO5eq3ZsEwbS/giphy.gif" Nothing Nothing (Just "https://media.giphy.com/media/zEO5eq3ZsEwbS/100.gif") Nothing Nothing Nothing Nothing Nothing
+inline_mpeg = InlineQueryResultMpeg4Gif "131251234" "https://media.giphy.com/media/zEO5eq3ZsEwbS/giphy.gif" Nothing Nothing (Just "https://media.giphy.com/media/zEO5eq3ZsEwbS/100.gif") Nothing Nothing Nothing Nothing Nothing
 inline_video = InlineQueryResultVideo "123413542" "https://www.youtube.com/embed/TBKN7_vx2xo" "text/html" (Just "https://i.ytimg.com/vi_webp/TBKN7_vx2xo/mqdefault.webp") (Just "Enjoykin — Nyash Myash") Nothing Nothing Nothing Nothing Nothing Nothing Nothing

--- a/test/MainSpec.hs
+++ b/test/MainSpec.hs
@@ -14,7 +14,8 @@ import           Network.HTTP.Client       (newManager)
 import           Network.HTTP.Client.TLS   (tlsManagerSettings)
 import           Network.HTTP.Types.Status
 import           Paths_telegram_api
-import           Servant.Client
+import           Servant.Client     hiding (Response)
+import qualified Servant.Client.Core       as Core
 import           System.FilePath
 import           Test.Hspec
 import           TestCore
@@ -41,7 +42,7 @@ spec token chatId botName = do
     it "should return error message" $ do
       res <- sendMessage token (sendMessageRequest (ChatChannel "") "test message") manager
       nosuccess res
-      let Left FailureResponse { responseStatus = Status { statusMessage = msg } } = res
+      let Left (FailureResponse Core.Response { responseStatusCode = Status { statusMessage = msg } }) = res
       msg `shouldBe` "Bad Request"
 
     it "should send message markdown" $ do
@@ -99,7 +100,7 @@ spec token chatId botName = do
     it "should forward message" $ do
       res <- forwardMessage token (forwardMessageRequest chatId chatId 123000) manager
       nosuccess res
-      let Left FailureResponse { responseStatus = Status { statusMessage = msg } } = res
+      let Left (FailureResponse Core.Response { responseStatusCode = Status { statusMessage = msg } }) = res
       msg `shouldBe` "Bad Request"
 
   describe "/sendPhoto" $ do
@@ -107,7 +108,7 @@ spec token chatId botName = do
       let photo = (sendPhotoRequest (ChatChannel "") "photo_id") {
         photo_caption = Just "photo caption"
       }
-      Left FailureResponse { responseStatus = Status { statusMessage = msg } } <- sendPhoto token photo manager
+      Left (FailureResponse Core.Response { responseStatusCode = Status { statusMessage = msg } }) <- sendPhoto token photo manager
       msg `shouldBe` "Bad Request"
     it "should upload photo and resend it by id" $ do
       let fileUpload = localFileUpload $ testFile "christmas-cat.jpg"
@@ -132,7 +133,7 @@ spec token chatId botName = do
         _audio_performer = Just "performer"
       , _audio_title = Just "title"
       }
-      Left FailureResponse { responseStatus = Status { statusMessage = msg } } <-
+      Left (FailureResponse Core.Response { responseStatusCode = Status { statusMessage = msg } }) <-
         sendAudio token audio manager
       msg `shouldBe` "Bad Request"
     it "should upload audio and resend it by id" $ do
@@ -264,7 +265,7 @@ spec token chatId botName = do
       fmap (T.take 10) (file_path file) `shouldBe` Just "thumbnails"
 
     it "should return error" $ do
-      Left FailureResponse { responseStatus = Status { statusMessage = msg } } <-
+      Left (FailureResponse Core.Response { responseStatusCode = Status { statusMessage = msg } }) <-
         getFile token "AAQEABMXDZEwAARC0Kj3twkzNcMkAmm" manager
       msg `shouldBe` "Bad Request"
 


### PR DESCRIPTION
Relates to #110
- Applied changes described in [changelog of 0.12](https://github.com/haskell-servant/servant/blob/master/servant/CHANGELOG.md). 
- Applied name changes for functions and types mostly similar to `req` now `request`.
- Import new modules where required. 
 - Fixed tests

I didn't run the integration tests.