### PR TITLE
use POST requests with ReqBody

### DIFF
--- a/src/Web/Telegram/API/Bot/API/Updates.hs
+++ b/src/Web/Telegram/API/Bot/API/Updates.hs
@@ -35,10 +35,10 @@ import           Web.Telegram.API.Bot.Responses
 type TelegramBotUpdatesAPI =
          TelegramToken :> "getUpdates"
          :> ReqBody '[JSON] GetUpdatesRequest
-         :> Get '[JSON] UpdatesResponse
+         :> Post '[JSON] UpdatesResponse
     :<|> TelegramToken :> "setWebhook"
          :> ReqBody '[JSON] SetWebhookRequest
-         :> Get '[JSON] SetWebhookResponse
+         :> Post '[JSON] SetWebhookResponse
     :<|> TelegramToken :> "setWebhook"
          :> MultipartFormDataReqBody SetWebhookRequest
          :> Post '[JSON] SetWebhookResponse


### PR DESCRIPTION
Currently `getUpdates` method ignores all input parameters, such as `offset` and `timeout`, so it's basically impossible to fetch updates (it returns the same updates over and over again). Seems like using GET HTTP method with request body is the problem. I'm not sure whether `servant` doesn't send request body data within GET request, or that request data is simply ignored in GET requests by Telegram servers. Anyway, changing HTTP method to POST fixes the problem.

I changed `setWebhook` method to POST as well (I didn't test it, as I don't use webhooks). All other requests in the library already use POST if `ReqBody` is present.