### PR TITLE
GHC 8.10 and 9.0 Compatibility

### DIFF
--- a/src/Web/Telegram/API/Bot/API/Core.hs
+++ b/src/Web/Telegram/API/Bot/API/Core.hs
@@ -44,7 +44,7 @@ runClient' tcm token = runClientM (runReaderT tcm token)
 
 -- | Runs 'TelegramClient'
 runClient :: TelegramClient a -> Token -> Manager -> IO (Either ClientError a)
-runClient tcm token manager = runClient' tcm token (ClientEnv manager telegramBaseUrl Nothing)
+runClient tcm token manager = runClient' tcm token (mkClientEnv manager telegramBaseUrl)
 
 -- | Runs 'TelegramClient'
 runTelegramClient :: Token -> Manager -> TelegramClient a -> IO (Either ClientError a)
@@ -54,7 +54,7 @@ asking :: Monad m => (t -> m b) -> ReaderT t m b
 asking op = ask >>= \t -> lift $ op t
 
 run :: BaseUrl -> (Token -> a -> ClientM b) -> Token -> a -> Manager -> IO (Either ClientError b)
-run b e t r m = runClientM (e t r) (ClientEnv m b Nothing)
+run b e t r m = runClientM (e t r) (mkClientEnv m b)
 
 run_ :: Monad m => (a -> b -> m c) -> b -> ReaderT a m c
 run_ act request = asking $ flip act request

--- a/src/Web/Telegram/API/Bot/Data.hs
+++ b/src/Web/Telegram/API/Bot/Data.hs
@@ -290,16 +290,17 @@ instance FromJSON Animation where
 
 -- | This object represents a sticker.
 data Sticker = Sticker
-  {
-    sticker_file_id       :: Text             -- ^ Unique identifier for this file
-  , sticker_width         :: Int              -- ^ Sticker width
-  , sticker_height        :: Int              -- ^ Sticker height
-  , sticker_thumb         :: Maybe PhotoSize  -- ^ Sticker thumbnail in .webp or .jpg format
-  , sticker_emoji         :: Maybe Text       -- ^ Emoji associated with the sticker
-  , sticker_set_name      :: Maybe Text
-  , sticker_mask_position :: Maybe MaskPosition
-  , sticker_file_size     :: Maybe Int        -- ^ File size
-  } deriving (Show, Generic)
+  { sticker_file_id        :: Text             -- ^ Unique identifier for this file
+  , sticker_file_unique_id :: Text
+  , sticker_width          :: Int              -- ^ Sticker width
+  , sticker_height         :: Int              -- ^ Sticker height
+  , sticker_thumb          :: Maybe PhotoSize  -- ^ Sticker thumbnail in .webp or .jpg format
+  , sticker_emoji          :: Maybe Text       -- ^ Emoji associated with the sticker
+  , sticker_set_name       :: Maybe Text
+  , sticker_mask_position  :: Maybe MaskPosition
+  , sticker_file_size      :: Maybe Int        -- ^ File size
+  }
+  deriving (Show, Generic)
 
 instance ToJSON Sticker where
   toJSON = toJsonDrop 8

--- a/telegram-api.cabal
+++ b/telegram-api.cabal
@@ -12,11 +12,7 @@ copyright:           Alexey Rodiontsev (c) 2016
 category:            Web
 build-type:          Simple
 -- extra-source-files:
-tested-with:         GHC == 8.6.5
-                   , GHC == 8.8.4
-                   , GHC == 8.10.5
-                   , GHC == 8.10.7
-                   , GHC == 9.0.1
+tested-with:         GHC == {8.6.5, 8.8.4, 8.10.5, 8.10.7, 9.0.1}
 data-files:          test-data/christmas-cat.jpg
                    , test-data/cert.pem
                    , test-data/haskell-logo.webp

--- a/telegram-api.cabal
+++ b/telegram-api.cabal
@@ -1,9 +1,10 @@
+cabal-version:       3.4
 name:                telegram-api
 version:             0.7.1.0
 synopsis:            Telegram Bot API bindings
 description:         High-level bindings to the Telegram Bot API
 homepage:            http://github.com/klappvisor/haskell-telegram-api#readme
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Alexey Rodiontsev
 maintainer:          alex.rodiontsev@gmail.com
@@ -11,7 +12,11 @@ copyright:           Alexey Rodiontsev (c) 2016
 category:            Web
 build-type:          Simple
 -- extra-source-files:
-cabal-version:       >=1.10
+tested-with:         GHC == 8.6.5
+                   , GHC == 8.8.4
+                   , GHC == 8.10.5
+                   , GHC == 8.10.7
+                   , GHC == 9.0.1
 data-files:          test-data/christmas-cat.jpg
                    , test-data/cert.pem
                    , test-data/haskell-logo.webp
@@ -46,23 +51,22 @@ library
                      , Web.Telegram.API.Bot.API.Core
                      , Servant.Client.MultipartFormData
   build-depends:       base >= 4.7 && < 5
-                     , aeson
-                     , containers
-                     , http-api-data
-                     , http-client
-                     , servant
-                     , servant-client == 0.16
-                     , servant-client-core
-                     , mtl
-                     , text
-                     , transformers
-                     , http-media
-                     , http-types
-                     , mime-types
-                     , bytestring
-                     , string-conversions
-                     , binary
-  default-language:    Haskell2010
+                     , aeson ^>= {1.4.4, 1.5.6}
+                     , containers ^>= 0.6.0 
+                     , http-api-data ^>= 0.4.1
+                     , http-client ^>= {0.6.4, 0.7.0}
+                     , servant (>= 0.16 && < 0.18) || ^>= 0.18
+                     , servant-client (>= 0.16 && < 0.18) || ^>= 0.18
+                     , servant-client-core (>= 0.16 && < 0.18) || ^>= 0.18
+                     , mtl ^>= 2.2.2
+                     , text ^>= 1.2.3
+                     , transformers ^>= 0.5.6
+                     , http-media ^>= 0.8.0.0
+                     , http-types ^>= 0.12.3
+                     , mime-types ^>= 0.1.0.0
+                     , bytestring ^>= 0.10.8
+                     , string-conversions ^>= 0.4.0.1
+                     , binary ^>= 0.8.6
   ghc-options:         -Wall -fno-warn-name-shadowing -fno-warn-unused-binds
 
 test-suite telegram-api-test
@@ -76,6 +80,8 @@ test-suite telegram-api-test
                      , UpdatesSpec
                      , StickersSpec
                      , TestCore
+                     , Paths_telegram_api
+  autogen-modules:     Paths_telegram_api
   build-depends:       base
                      , aeson
                      , hjpath

--- a/test/MainSpec.hs
+++ b/test/MainSpec.hs
@@ -162,7 +162,7 @@ spec token chatId botName = do
       let sticker = sendStickerRequest chatId "BQADAgADGgADkWgMAAGXlYGBiM_d2wI"
       Right Response { result = Message { sticker = Just sticker } } <-
         sendSticker token sticker manager
-      sticker_file_id sticker `shouldBe` "CAADAgADGgADkWgMAAFNFIZh3zoKbRYE" --"BQADAgADGgADkWgMAAGXlYGBiM_d2wI"
+      sticker_file_unique_id sticker `shouldBe` "AgADGgADkWgMAAE" --"BQADAgADGgADkWgMAAGXlYGBiM_d2wI"
     it "should upload sticker" $ do
       let fileUpload = localFileUpload $ testFile "haskell-logo.webp"
           stickerReq = uploadStickerRequest chatId fileUpload
@@ -258,8 +258,9 @@ spec token chatId botName = do
 
   describe "/getFile" $ do
     it "should get file" $ do
-      Right Response { result = file } <-
-        getFile token "AAQEABMXDZEwAARC0Kj3twkzNcMkAAIC" manager
+      res <- getFile token "AAQEABMXDZEwAARC0Kj3twkzNcMkAAIC" manager
+      success res
+      Right Response { result = file } <- pure res
       fmap (T.take 10) (file_path file) `shouldBe` Just "thumbnails"
 
     it "should return error" $ do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -81,7 +81,7 @@ runIntegrationSpec (Just token) (Just chatId) (Just botName) (Just paymentToken)
         describe "Stickers API spec" $ StickersSpec.spec token chatId botName
             --describe "Inline integration tests" $ InlineSpec.spec token chatId botName
 runIntegrationSpec _ _ _ _ = describe "Integration tests" $
-        fail "Missing required arguments for integration tests. Run stack test --test-arguments \"--help\" for more info"
+        error "Missing required arguments for integration tests. Run stack test --test-arguments \"--help\" for more info"
 
 description ::  Maybe PP.Doc
 description = Just $


### PR DESCRIPTION
This PR does four things:

1. Repairs some tests
2. Opens up compatibility with more servant-client versions
3. Ups the cabal file spec version
4. Updates dependency bounds

Thanks mostly thanks to the loosening of the servant constraints, I have been able to successfully build this package under GHC 8.6.5, 8.8.4, 8.10.7 and 9.0.1

## Tests

The test repairs cover 3 problems:
1. `runIntegrationSpec` expected `SpecWith` to satisfy the `MonadFail` constraint which isn't the case (at least with with modern `hspec` versions).
2. The /getFile test assumed that it would get a successful response (which wasn't happening).
3. Sticker tests were checking that a returned sticker was correct with an id field that can no-longer be considered unchanging for each sticker, so I added the sticker_file_unique_id field from the current version of the telegram API.

⚠The addition of the `sticker_file_unique_id` adds to the interface so at least a minor version bump will be required on release.

What this doesn't do is guarantee that all tests are working nor fix all failing tests that may be a result from incompatibilities with the current version of the Telegram API.

## Servant-Client Compatibility

Most of the incompatibility seemed to come from dependence on internal servant modules which subsequently underwent minor changes like renamings.

The fixes should be simple and self-explanatory. All tests except 1 passed, which I believe to be is unrelated and caused by an outdated hardcoded file id
```
  test/TestCore.hs:15:15: 
  1) Main integration tests, /getFile, should get file
       predicate failed on: Left (FailureResponse (Request {requestPath = (BaseUrl {baseUrlScheme = Https, baseUrlHost = "api.telegram.org", baseUrlPort = 443, baseUrlPath = ""},"/bot1159302136:AAG8MeT_d3Ds2gPlso1Zur0yIBVOhR8bztk/getFile"), requestQueryString = fromList [("file_id",Just "AAQEABMXDZEwAARC0Kj3twkzNcMkAAIC")], requestBody = Nothing, requestAccept = fromList [application/json;charset=utf-8,application/json], requestHeaders = fromList []), requestHttpVersion = HTTP/1.1, requestMethod = "GET"} (Response {responseStatusCode = Status {statusCode = 400, statusMessage = "Bad Request"}, responseHeaders = fromList [("Server","nginx/1.18.0"),("Date","Mon, 18 Oct 2021 15:19:34 GMT"),("Content-Type","application/json"),("Content-Length","111"),("Connection","keep-alive"),("Strict-Transport-Security","max-age=31536000; includeSubDomains; preload"),("Access-Control-Allow-Origin","*"),("Access-Control-Expose-Headers","Content-Length,Content-Type,Date,Server,Connection")], responseHttpVersion = HTTP/1.1, responseBody = "{\"ok\":false,\"error_code\":400,\"description\":\"Bad Request: wrong file_id or the file is temporarily unavailable\"}"}))
```

This fixes #132

To maintain compatibility between both old and new versions of servant I had to resort to a little CPP usage.
I'd prefer to avoid it since in my experience it tends to cause problems with tooling, but dropping compatability with servant-client 0.16 would also drop support with stackage LTS 14, 15 and 16 and therefore support for GHC 8.6 and 8.8 for stackage users.

I expect it may be possible to avoid depending on the internal modules to make this less of an issue.

## Upping the Cabal Spec Version

The cabal file was originally on `cabal-version >=1.10`
Later cabal versions add convenient improvements to cabal file syntax and also provide more information so that tools lik HLS can function, IIRC, such as through the autogen-modules field.

I don't think it likely that there are any users out there who desperately need support for old versions of cabal or stack so I don't think it's too much of an issue to drop support for them.

As such I've upped the `cabal-version` to `3.4`, and made some adjustments to make it compliant.

## Dependency bounds.

I have added upper and lower bounds to every library dependency in accordance with the Hackage PVP. This will avoid tools resolving build plans that seem valid but lead to build errors.

These bounds are broad enough to build on GHC 8.6.5 through to GHC 9.0.1 according to my testing.

This fixes #130.

The dependency bounds on servant libs currently look a little odd:
```
, servant (>= 0.16 && < 0.18) || ^>= 0.18
, servant-client (>= 0.16 && < 0.18) || ^>= 0.18
, servant-client-core (>= 0.16 && < 0.18) || ^>= 0.18
```
[This is because the `^>= 0.18` has subtly different semantics from `< 0.19`](https://www.haskell.org/cabal/release/latest/doc/users-guide/developing-packages.html#pkg-field-build-depends)

I could've just done this:
```
, servant ^>= {0.16, 0.17, 0.18}
, servant-client ^>= {0.16, 0.17, 0.18}
, servant-client-core ^>= {0.16, 0.17, 0.18}
```
But as more major versions come along those sets are only going to get larger.
I'm happy to change it if preferred.